### PR TITLE
Feat: Add Support for Nord Theme 🏔️

### DIFF
--- a/src-web/lib/theme/themes.ts
+++ b/src-web/lib/theme/themes.ts
@@ -4,6 +4,7 @@ import { catppuccin } from './themes/catppuccin';
 import { github } from './themes/github';
 import { hotdogStand } from './themes/hotdog-stand';
 import { monokaiPro } from './themes/monokai-pro';
+import { nord } from './themes/nord';
 import { relaxing } from './themes/relaxing';
 import { rosePine } from './themes/rose-pine';
 import { yaak, yaakDark, yaakLight } from './themes/yaak';
@@ -19,6 +20,7 @@ const allThemes = [
   ...rosePine,
   ...github,
   ...monokaiPro,
+	...nord,
   ...hotdogStand,
 ];
 

--- a/src-web/lib/theme/themes/nord.ts
+++ b/src-web/lib/theme/themes/nord.ts
@@ -1,0 +1,30 @@
+import type { YaakTheme } from '../window';
+import { YaakColor } from '../yaakColor';
+
+const nordDefault: YaakTheme = {
+  id: 'nord',
+  name: 'Nord',
+  surface: new YaakColor('hsl(220, 16%, 22%)', 'dark'),          // Nord0 (#2e3440)
+  surfaceHighlight: new YaakColor('hsl(220, 14%, 28%)', 'dark'), // Nord1 (#3b4252)
+  text: new YaakColor('hsl(220, 28%, 93%)', 'dark'),             // Nord6 (#ECEFF4)
+  textSubtle: new YaakColor('hsl(220, 26%, 90%)', 'dark'),       // Nord5 (#E5E9F0)
+  textSubtlest: new YaakColor('hsl(220, 24%, 86%)', 'dark'),     // Nord4 (#D8DEE9)
+  primary: new YaakColor('hsl(193, 38%, 68%)', 'dark'),          // Nord8 (#88C0D0)
+  secondary: new YaakColor('hsl(210, 34%, 63%)', 'dark'),        // Nord9 (#81A1C1)
+  info: new YaakColor('hsl(174, 25%, 69%)', 'dark'),             // Nord7 (#8FBCBB)
+  success: new YaakColor('hsl(89, 26%, 66%)', 'dark'),           // Nord14 (#A3BE8C)
+  notice: new YaakColor('hsl(40, 66%, 73%)', 'dark'),            // Nord13 (#EBCB8B)
+  warning: new YaakColor('hsl(17, 48%, 64%)', 'dark'),           // Nord12 (#D08770)
+  danger: new YaakColor('hsl(353, 43%, 56%)', 'dark'),           // Nord11 (#BF616A)
+  components: {
+    sidebar: {
+      backdrop: new YaakColor('hsl(220, 16%, 22%)', 'dark'),     // Nord0 (#2e3440)
+    },
+    appHeader: {
+      backdrop: new YaakColor('hsl(220, 14%, 28%)', 'dark'),     // Nord1 (#3b4252)
+    },
+  },
+};
+
+export const nord = [nordDefault];
+


### PR DESCRIPTION
> [!NOTE]  
> I just realized after creating this PR that the contribution policy specifies that only bug fixes are being accepted. I apologise for the oversight and understand completely if this PR is closed because it doesn’t align with the policy.
>
> Thank you for your time and the amazing project.


This PR adds support for the [Nord theme](https://www.nordtheme.com) to Yaak 🏔️. As a fan of the Nord theme, I find its calm and cohesive design delightful, and I believe other users who love Nord will enjoy having it as an option within Yaak.

#### Why [Nord Theme](https://www.nordtheme.com)?
The Nord theme is an arctic, north-bluish colour palette created for a clean and uncluttered design pattern. It is crafted to achieve optimal focus and readability for code syntax highlighting and UI components. Known for its consistent aesthetic and harmonious blend of tones, Nord reduces eye strain while enhancing usability, making it a great choice for users who value both style and functionality.

#### Changes Introduced:
1. Registered the Nord theme in the `themes.ts` file.
2. Added a new `nord.ts` file defining the colour system using the `YaakColor` API.

#### Testing:
To test this PR:
1. Select the **Nord theme** from the theme menu.
2. Verify the consistency of the colour system across the UI, including elements such as the sidebar and header.
3. Ensure readability and usability meet expected standards.

#### Resources:
- [Official Nord Theme Website](https://www.nordtheme.com)
- [Nord Theme Documentation](https://www.nordtheme.com/docs/)

Thank you for considering this PR!  I look forward to your feedback.
