### PR TITLE
Fix: Settings Window Title Bar Draggable Region Deadzone

### DIFF
--- a/src-web/components/WindowControls.tsx
+++ b/src-web/components/WindowControls.tsx
@@ -27,6 +27,7 @@ export function WindowControls({ className, onlyX }: Props) {
       className={classNames(className, 'ml-4 absolute right-0 top-0 bottom-0')}
       justifyContent="end"
       style={{ width: WINDOW_CONTROLS_WIDTH }}
+      data-tauri-drag-region
     >
       {!onlyX && (
         <>


### PR DESCRIPTION
**Issue:**
Settings window is not draggable in this region:
![image](https://github.com/user-attachments/assets/5b5c33c1-bd26-4295-902c-836559ef14c2)

**Solution:**
This can be corrected by adding the `data-tauri-drag-region` prop to the `WindowControls` component.

Alternatively, users of `WINDOW_CONTROLS_WIDTH` could compute the true width of the windows controls based on which controls are available.