### PR TITLE
feat: add gruvbox dark theme

### DIFF
--- a/src-web/lib/theme/themes.ts
+++ b/src-web/lib/theme/themes.ts
@@ -3,6 +3,7 @@ import { resolveAppearance } from './appearance';
 import { catppuccin } from './themes/catppuccin';
 import { dracula } from './themes/dracula';
 import { github } from './themes/github';
+import { gruvbox } from './themes/gruvbox';
 import { hotdogStand } from './themes/hotdog-stand';
 import { monokaiPro } from './themes/monokai-pro';
 import { nord } from './themes/nord';
@@ -22,8 +23,9 @@ const allThemes = [
   ...relaxing,
   ...rosePine,
   ...github,
+  ...gruvbox,
   ...monokaiPro,
-	...nord,
+  ...nord,
   ...moonlight,
   ...hotdogStand,
 ];

--- a/src-web/lib/theme/themes/gruvbox.ts
+++ b/src-web/lib/theme/themes/gruvbox.ts
@@ -1,0 +1,29 @@
+import type { YaakTheme } from '../window';
+import { YaakColor } from '../yaakColor';
+
+const gruvboxDefault: YaakTheme = {
+  id: 'gruvbox',
+  name: 'gruvbox',
+  surface: new YaakColor('#282828', 'dark'),             // Gruvbox bg
+  surfaceHighlight: new YaakColor('#3c3836', 'dark'),    // Gruvbox bg1
+  text: new YaakColor('#ebdbb2', 'dark'),                // Gruvbox fg
+  textSubtle: new YaakColor('#fe8019', 'dark'),          // Gruvbox orange
+  textSubtlest: new YaakColor('#665c54', 'dark'),        // Gruvbox bg4
+  primary: new YaakColor('#d3869b', 'dark'),             // Gruvbox purple
+  secondary: new YaakColor('#83a598', 'dark'),           // Gruvbox blue
+  info: new YaakColor('#8ec07c', 'dark'),                // Gruvbox aqua
+  success: new YaakColor('#b8bb26', 'dark'),             // Gruvbox green
+  notice: new YaakColor('#fabd2f', 'dark'),              // Gruvbox yellow
+  warning: new YaakColor('#fe8019', 'dark'),             // Gruvbox orange
+  danger: new YaakColor('#fb4934', 'dark'),              // Gruvbox red
+  components: {
+    sidebar: {
+      backdrop: new YaakColor('#282828', 'dark'),        // Gruvbox bg
+    },
+    appHeader: {
+      backdrop: new YaakColor('#3c3836', 'dark'),        // Gruvbox bg1
+    },
+  },
+};
+
+export const gruvbox = [gruvboxDefault];


### PR DESCRIPTION
this PR adds support for [gruvbox](https://github.com/morhetz/gruvbox) dark theme

![image](https://github.com/user-attachments/assets/0081ad42-0e1c-4fb4-9e75-ad9c7637f29d)

open to any feedback as this is my first port of a theme!