### PR TITLE
feat: add kanagawa dragon theme

### DIFF
--- a/src-web/lib/theme/themes.ts
+++ b/src-web/lib/theme/themes.ts
@@ -10,6 +10,7 @@ import { nord } from './themes/nord';
 import { moonlight } from './themes/moonlight';
 import { relaxing } from './themes/relaxing';
 import { rosePine } from './themes/rose-pine';
+import { kanagawa } from './themes/kanagawa';
 import { yaak, yaakDark, yaakLight } from './themes/yaak';
 import { isThemeDark } from './window';
 
@@ -28,6 +29,7 @@ const allThemes = [
   ...nord,
   ...moonlight,
   ...hotdogStand,
+  ...kanagawa,
 ];
 
 export function getThemes() {

--- a/src-web/lib/theme/themes/kanagawa.ts
+++ b/src-web/lib/theme/themes/kanagawa.ts
@@ -1,0 +1,41 @@
+import { YaakColor } from '../yaakColor';
+import type { YaakTheme } from '../window';
+
+const kanagawaDragon: YaakTheme = {
+  id: 'kanagawa-dragon',
+  name: 'Kanagawa Dragon',
+  surface: new YaakColor('#181616', 'dark'),
+  border: new YaakColor('#3B4045', 'dark'),
+  surfaceHighlight: new YaakColor('#393836', 'dark'),
+  text: new YaakColor('#C5C9C5', 'dark'),
+  textSubtle: new YaakColor('#C8C093', 'dark'),
+  textSubtlest: new YaakColor('#8EA4A2', 'dark'),
+  primary: new YaakColor('#C8C093', 'dark').lift(0.1),
+  secondary: new YaakColor('#C5C9C5', 'dark').lift(0.1),
+  info: new YaakColor('#C5C9C5', 'dark').lift(0.1),
+  success: new YaakColor('#87A987', 'dark').lift(0.1),
+  notice: new YaakColor('#E6C384', 'dark').lift(0.1),
+  warning: new YaakColor('#C4746E', 'dark').lift(0.1),
+  danger: new YaakColor('#E46876', 'dark').lift(0.1),
+  components: {
+    button: {
+      primary: new YaakColor('#C8C093', 'dark'),
+      secondary: new YaakColor('#7b6c9e', 'dark'),
+      info: new YaakColor('#7FB4CA', 'dark'),
+      success: new YaakColor('#87A987', 'dark'),
+      notice: new YaakColor('#E6C384', 'dark'),
+      warning: new YaakColor('#C4746E', 'dark'),
+      danger: new YaakColor('#E46876', 'dark'),
+    },
+    editor: {
+      primary: new YaakColor('#A292A3', 'dark'),
+      secondary: new YaakColor('#aa0000', 'dark'),
+      info: new YaakColor('#A292A3', 'dark'),
+      success: new YaakColor('#c5c9c5', 'dark'),
+      notice: new YaakColor('#8A9A7B', 'dark'),
+      danger: new YaakColor('#B6927B', 'dark'),
+    },
+  },
+};
+
+export const kanagawa = [kanagawaDragon];

--- a/src-web/lib/theme/themes/kanagawa.ts
+++ b/src-web/lib/theme/themes/kanagawa.ts
@@ -20,7 +20,7 @@ const kanagawaDragon: YaakTheme = {
   components: {
     button: {
       primary: new YaakColor('#C8C093', 'dark'),
-      secondary: new YaakColor('#7b6c9e', 'dark'),
+      secondary: new YaakColor('#7B6C9E', 'dark'),
       info: new YaakColor('#7FB4CA', 'dark'),
       success: new YaakColor('#87A987', 'dark'),
       notice: new YaakColor('#E6C384', 'dark'),
@@ -29,9 +29,9 @@ const kanagawaDragon: YaakTheme = {
     },
     editor: {
       primary: new YaakColor('#A292A3', 'dark'),
-      secondary: new YaakColor('#aa0000', 'dark'),
+      secondary: new YaakColor('#AA0000', 'dark'),
       info: new YaakColor('#A292A3', 'dark'),
-      success: new YaakColor('#c5c9c5', 'dark'),
+      success: new YaakColor('#C5C9C5', 'dark'),
       notice: new YaakColor('#8A9A7B', 'dark'),
       danger: new YaakColor('#B6927B', 'dark'),
     },


### PR DESCRIPTION
This **PR** adds support for the Kanagawa Dragon theme, with some tweaks to better fit Yaak's style flow.

### **Why do I suggest adding Kanagawa to Yaak?**

I've been using Yaak regularly since June/July, and since Kanagawa Dragon is one of the most popular themes in Neovim, I think it would be a great addition. For me, this theme helps rest my eyes, and I believe others could benefit from it as well.

### **Preview:**
![image](https://github.com/user-attachments/assets/f410fba8-f2ee-434e-8b86-cc369054ab71)

### **References**

- [Kanagawa Repo](https://github.com/rebelot/kanagawa.nvim)