### PR TITLE
parse params when url changed

### DIFF
--- a/src-web/components/HttpRequestPane.tsx
+++ b/src-web/components/HttpRequestPane.tsx
@@ -353,8 +353,14 @@ export function HttpRequestPane({ style, fullHeight, className, activeRequest }:
   );
 
   const handleUrlChange = useCallback(
-    (url: string) => updateRequest({ id: activeRequestId, update: { url } }),
-    [activeRequestId, updateRequest],
+    (url: string) => {
+      if (url.indexOf("?") > 0){
+        importQuerystring(url);
+      } else {
+        updateRequest({ id: activeRequestId, update: { url } });
+      }
+    },
+    [activeRequestId, updateRequest, importQuerystring],
   );
 
   return (


### PR DESCRIPTION
To fix [url pasted params parsed incorrectly](https://feedback.yaak.app/p/url-pasted-params-parsed-incorrectly)
