### PR TITLE
fix plugin manager listen addr

### DIFF
--- a/src-tauri/yaak-plugins/src/manager.rs
+++ b/src-tauri/yaak-plugins/src/manager.rs
@@ -79,8 +79,8 @@ impl PluginManager {
         });
 
         let listen_addr = match option_env!("YAAK_PLUGIN_SERVER_PORT") {
-            Some(port) => format!("localhost:{port}"),
-            None => "localhost:0".to_string(),
+            Some(port) => format!("127.0.0.1:{port}"),
+            None => "127.0.0.1:0".to_string(),
         };
         let listener = tauri::async_runtime::block_on(async move {
             TcpListener::bind(listen_addr).await.expect("Failed to bind TCP listener")


### PR DESCRIPTION
When both `IPv4` and `IPv6` are enabled (dual-stack), `localhost` resolves to `::1` (`IPv6`), causing the plugin ​`yaaknode​` to fail to connect, which subsequently leads to application startup failure. Therefore, we explicitly use the `IPv4` `localhost` address (`127.0.0.1`) here.

![image](https://github.com/user-attachments/assets/5d4a31a5-bd1e-4035-a0e3-23850d020f23)
