### PR TITLE
Fix font aliasing on webkit.

### DIFF
--- a/src-web/main.css
+++ b/src-web/main.css
@@ -11,6 +11,12 @@
 
   * {
     font-variant-ligatures: none;
+
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-text-size-adjust: 100%;
   }
 
   ::selection {


### PR DESCRIPTION
Hi, love the app!

Font rendering on Linux (Ubuntu 22.04) looked very broken. I have seem this issue on other Tauri apps as well.
The only Tauri app I found without this issue is JetPilot, where I got this [snippet from.](https://github.com/unxsist/jet-pilot/blob/4d11eeb203d4a7205611134746ab64d580d3d7db/src/assets/main.postcss#L82-L86)

Now:
![image](https://github.com/user-attachments/assets/a7442248-6973-4237-ab0b-3f8baaff452a)

Patched:
![image](https://github.com/user-attachments/assets/892cf000-b225-4bd6-96a9-6fda68633359)

I am not really sure that it looks perfect either, as it's not subpixel antialiased, but I think it's the best we can get on webkit gtk, and it's unusable without it.
I also cannot test it on windows/macos, so I understand if you don't accept this patch now.
Would be good to have feedback from other users on linux or macos, which may have the same problem with webkit.