### PR TITLE
Fix wrong protoc includes path

### DIFF
--- a/src-tauri/yaak-grpc/src/reflection.rs
+++ b/src-tauri/yaak-grpc/src/reflection.rs
@@ -28,7 +28,7 @@ pub async fn fill_pool_from_files(
     let desc_path = temp_dir().join(random_file_name);
     let global_import_dir = app_handle
         .path()
-        .resolve("vendored/protoc/protoc-include", BaseDirectory::Resource)
+        .resolve("vendored/protoc/protoc", BaseDirectory::Resource)
         .expect("failed to resolve protoc include directory");
 
     // HACK: Remove UNC prefix for Windows paths

--- a/src-tauri/yaak-grpc/src/reflection.rs
+++ b/src-tauri/yaak-grpc/src/reflection.rs
@@ -28,7 +28,7 @@ pub async fn fill_pool_from_files(
     let desc_path = temp_dir().join(random_file_name);
     let global_import_dir = app_handle
         .path()
-        .resolve("vendored/protoc/protoc", BaseDirectory::Resource)
+        .resolve("vendored/protoc/include", BaseDirectory::Resource)
         .expect("failed to resolve protoc include directory");
 
     // HACK: Remove UNC prefix for Windows paths


### PR DESCRIPTION
The path specified in the build script is different than the path referenced in the code: https://github.com/mountain-loop/yaak/blob/7a1a0689b03d127dc36bc5cd4694d8a2fcfac5bc/scripts/vendor-protoc.cjs#L36

Loving your work on yaak BTW!