### PR TITLE
Fix header layout

### DIFF
--- a/src-web/components/HeaderSize.tsx
+++ b/src-web/components/HeaderSize.tsx
@@ -33,8 +33,8 @@ export function HeaderSize({
         // Add padding for macOS stoplights, but keep it the same width (account for the interface scale)
         paddingLeft:
           stoplightsVisible && !ignoreControlsSpacing ? 72 / settings.interfaceScale : undefined,
-        ...(size === 'md' ? { height: HEADER_SIZE_MD } : {}),
-        ...(size === 'lg' ? { height: HEADER_SIZE_LG } : {}),
+        ...(size === 'md' ? { minHeight: HEADER_SIZE_MD } : {}),
+        ...(size === 'lg' ? { minHeight: HEADER_SIZE_LG } : {}),
         ...(osInfo.osType === 'macos' || ignoreControlsSpacing
           ? { paddingRight: '2px' }
           : { paddingLeft: '2px', paddingRight: WINDOW_CONTROLS_WIDTH }),


### PR DESCRIPTION
## Before
When the font size exceeds 24px, the header layout will overflow.

<img width="1741" alt="SCR-20250309-lpyz" src="https://github.com/user-attachments/assets/26d0025b-1111-49f1-9ae7-982f8f284d54" />
<img width="1744" alt="SCR-20250309-lsja" src="https://github.com/user-attachments/assets/2645a2b0-b76d-4336-9036-9b08df292bf2" />

## After
Use min height for header layout.

<img width="1742" alt="SCR-20250309-lugu" src="https://github.com/user-attachments/assets/32ad7d7c-8e20-47b7-81d6-27e5fb595b29" />
