### PR TITLE
Fix labels in GRPC service/method selector dropdown

### DIFF
--- a/src-web/components/GrpcConnectionSetupPane.tsx
+++ b/src-web/components/GrpcConnectionSetupPane.tsx
@@ -92,7 +92,7 @@ export function GrpcConnectionSetupPane({
     const options =
       services?.flatMap((s) =>
         s.methods.map((m) => ({
-          label: `${s.name.split('.', 2).pop() ?? s.name}/${m.name}`,
+          label: `${s.name.split('.').pop() ?? s.name}/${m.name}`,
           value: `${s.name}/${m.name}`,
         })),
       ) ?? [];


### PR DESCRIPTION
Comparison using the `connectrpc.eliza.v1.ElizaService` service @ https://demo.connectrpc.com:443:

Before:

<img width="877" alt="before" src="https://github.com/user-attachments/assets/da037871-0306-4136-adcf-0638100519b6" />

After:

<img width="877" alt="after" src="https://github.com/user-attachments/assets/a26f6f05-7d6b-432f-8949-54d2d3da80ab" />

Note that other places in the code already use the correct logic, for example: https://github.com/mountain-loop/yaak/blob/6aea343d4f5985de912b94220e6bc2cfcd4c5152/src-web/lib/resolvedModelName.ts#L29-L30