### PR TITLE
Queries now use AppHandle instead of Window

### DIFF
--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -6,7 +6,7 @@ use log::debug;
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tauri::{Emitter, Manager, Runtime, WebviewWindow};
+use tauri::{AppHandle, Emitter, Manager, Runtime, WebviewWindow};
 use yaak_models::queries::{get_key_value_raw, set_key_value_raw, UpdateSource};
 
 // Check for updates every hour
@@ -43,16 +43,18 @@ impl YaakNotifier {
         }
     }
 
-    pub async fn seen<R: Runtime>(&mut self, w: &WebviewWindow<R>, id: &str) -> Result<(), String> {
-        let mut seen = get_kv(w).await?;
+    pub async fn seen<R: Runtime>(&mut self, window: &WebviewWindow<R>, id: &str) -> Result<(), String> {
+        let app_handle = window.app_handle();
+        let mut seen = get_kv(app_handle).await?;
         seen.push(id.to_string());
         debug!("Marked notification as seen {}", id);
         let seen_json = serde_json::to_string(&seen).map_err(|e| e.to_string())?;
-        set_key_value_raw(w, KV_NAMESPACE, KV_KEY, seen_json.as_str(), &UpdateSource::Window).await;
+        set_key_value_raw(app_handle, KV_NAMESPACE, KV_KEY, seen_json.as_str(), &UpdateSource::from_window(window)).await;
         Ok(())
     }
 
     pub async fn check<R: Runtime>(&mut self, window: &WebviewWindow<R>) -> Result<(), String> {
+        let app_handle = window.app_handle();
         let ignore_check = self.last_check.elapsed().unwrap().as_secs() < MAX_UPDATE_CHECK_SECONDS;
 
         if ignore_check {
@@ -61,8 +63,8 @@ impl YaakNotifier {
 
         self.last_check = SystemTime::now();
 
-        let num_launches = get_num_launches(window).await;
-        let info = window.app_handle().package_info().clone();
+        let num_launches = get_num_launches(app_handle).await;
+        let info = app_handle.package_info().clone();
         let req = reqwest::Client::default()
             .request(Method::GET, "https://notify.yaak.app/notifications")
             .query(&[
@@ -90,14 +92,14 @@ impl YaakNotifier {
 
         for notification in notifications {
             let age = notification.timestamp.signed_duration_since(Utc::now());
-            let seen = get_kv(window).await?;
+            let seen = get_kv(app_handle).await?;
             if seen.contains(&notification.id) || (age > Duration::days(2)) {
                 debug!("Already seen notification {}", notification.id);
                 continue;
             }
             debug!("Got notification {:?}", notification);
 
-            let _ = window.emit_to(window.label(), "notification", notification.clone());
+            let _ = app_handle.emit_to(window.label(), "notification", notification.clone());
             break; // Only show one notification
         }
 
@@ -105,8 +107,8 @@ impl YaakNotifier {
     }
 }
 
-async fn get_kv<R: Runtime>(w: &WebviewWindow<R>) -> Result<Vec<String>, String> {
-    match get_key_value_raw(w, "notifications", "seen").await {
+async fn get_kv<R: Runtime>(app_handle: &AppHandle<R>) -> Result<Vec<String>, String> {
+    match get_key_value_raw(app_handle, "notifications", "seen").await {
         None => Ok(Vec::new()),
         Some(v) => serde_json::from_str(&v.value).map_err(|e| e.to_string()),
     }

--- a/src-tauri/src/plugin_events.rs
+++ b/src-tauri/src/plugin_events.rs
@@ -18,8 +18,8 @@ use yaak_models::queries::{
 use yaak_plugins::events::{
     Color, DeleteKeyValueResponse, EmptyPayload, FindHttpResponsesResponse,
     GetHttpRequestByIdResponse, GetKeyValueResponse, Icon, InternalEvent, InternalEventPayload,
-    RenderHttpRequestResponse, SendHttpRequestResponse, SetKeyValueResponse, ShowToastRequest,
-    TemplateRenderResponse, WindowContext, WindowNavigateEvent,
+    RenderHttpRequestResponse, RenderPurpose, SendHttpRequestResponse, SetKeyValueResponse,
+    ShowToastRequest, TemplateRenderResponse, WindowContext, WindowNavigateEvent,
 };
 use yaak_plugins::manager::PluginManager;
 use yaak_plugins::plugin_handle::PluginHandle;
@@ -80,7 +80,7 @@ pub(crate) async fn handle_plugin_event<R: Runtime>(
                 .await
                 .expect("Failed to get workspace_id from window URL");
             let environment = environment_from_window(&window).await;
-            let base_environment = get_base_environment(&window, workspace.id.as_str())
+            let base_environment = get_base_environment(app_handle, workspace.id.as_str())
                 .await
                 .expect("Failed to get base environment");
             let cb = PluginTemplateCallback::new(app_handle, &window_context, req.purpose);
@@ -104,7 +104,7 @@ pub(crate) async fn handle_plugin_event<R: Runtime>(
                 .await
                 .expect("Failed to get workspace_id from window URL");
             let environment = environment_from_window(&window).await;
-            let base_environment = get_base_environment(&window, workspace.id.as_str())
+            let base_environment = get_base_environment(app_handle, workspace.id.as_str())
                 .await
                 .expect("Failed to get base environment");
             let cb = PluginTemplateCallback::new(app_handle, &window_context, req.purpose);
@@ -145,7 +145,7 @@ pub(crate) async fn handle_plugin_event<R: Runtime>(
                     updated_at: Utc::now().naive_utc(), // TODO: Add reloaded_at field to use instead
                     ..plugin
                 };
-                upsert_plugin(&window, new_plugin, &UpdateSource::Plugin).await.unwrap();
+                upsert_plugin(app_handle, new_plugin, &UpdateSource::Plugin).await.unwrap();
             }
             let toast_event = plugin_handle.build_event_to_send(
                 &WindowContext::from_window(&window),
@@ -177,7 +177,7 @@ pub(crate) async fn handle_plugin_event<R: Runtime>(
                 HttpResponse::new()
             } else {
                 create_default_http_response(
-                    &window,
+                    app_handle,
                     http_request.id.as_str(),
                     &UpdateSource::Plugin,
                 )

--- a/src-tauri/yaak-models/bindings/gen_models.ts
+++ b/src-tauri/yaak-models/bindings/gen_models.ts
@@ -44,7 +44,7 @@ export type HttpUrlParameter = { enabled?: boolean, name: string, value: string,
 
 export type KeyValue = { model: "key_value", createdAt: string, updatedAt: string, key: string, namespace: string, value: string, };
 
-export type ModelPayload = { model: AnyModel, windowLabel: string, updateSource: UpdateSource, };
+export type ModelPayload = { model: AnyModel, updateSource: UpdateSource, };
 
 export type Plugin = { model: "plugin", id: string, createdAt: string, updatedAt: string, checkedAt: string | null, directory: string, enabled: boolean, url: string | null, };
 
@@ -60,7 +60,7 @@ export type SyncHistory = { model: "sync_history", id: string, workspaceId: stri
 
 export type SyncState = { model: "sync_state", id: string, workspaceId: string, createdAt: string, updatedAt: string, flushedAt: string, modelId: string, checksum: string, relPath: string, syncDir: string, };
 
-export type UpdateSource = "sync" | "window" | "plugin" | "background" | "import";
+export type UpdateSource = { "type": "sync" } | { "type": "window", label: string, } | { "type": "plugin" } | { "type": "background" } | { "type": "import" };
 
 export type WebsocketConnection = { model: "websocket_connection", id: string, createdAt: string, updatedAt: string, workspaceId: string, requestId: string, elapsed: number, error: string | null, headers: Array<HttpResponseHeader>, state: WebsocketConnectionState, status: number, url: string, };
 

--- a/src-tauri/yaak-models/src/error.rs
+++ b/src-tauri/yaak-models/src/error.rs
@@ -4,10 +4,16 @@ use thiserror::Error;
 pub enum Error {
     #[error("SQL error: {0}")]
     SqlError(#[from] rusqlite::Error),
+
+    #[error("SQL Pool error: {0}")]
+    SqlPoolError(#[from] r2d2::Error),
+
     #[error("JSON error: {0}")]
     JsonError(#[from] serde_json::Error),
+
     #[error("Model not found {0}")]
     ModelNotFound(String),
+
     #[error("unknown error")]
     Unknown,
 }

--- a/src-tauri/yaak-models/src/lib.rs
+++ b/src-tauri/yaak-models/src/lib.rs
@@ -4,3 +4,4 @@ pub mod queries;
 
 pub mod plugin;
 pub mod render;
+pub mod manager;

--- a/src-tauri/yaak-models/src/manager.rs
+++ b/src-tauri/yaak-models/src/manager.rs
@@ -1,0 +1,40 @@
+use crate::error::Result;
+use crate::models::{Workspace, WorkspaceIden};
+use crate::plugin::SqliteConnection;
+use r2d2::{Pool, PooledConnection};
+use r2d2_sqlite::SqliteConnectionManager;
+use rusqlite::Connection;
+use sea_query::{Asterisk, Order, Query, SqliteQueryBuilder};
+use sea_query_rusqlite::RusqliteBinder;
+use std::future::Future;
+use std::ops::Deref;
+use tauri::{AppHandle, Manager, Runtime};
+
+pub struct QueryManager {
+    pool: Pool<SqliteConnectionManager>,
+}
+
+pub trait DBConnection {
+    fn connect(
+        &self,
+    ) -> impl Future<Output = Result<PooledConnection<SqliteConnectionManager>>> + Send;
+}
+
+impl<R: Runtime> DBConnection for AppHandle<R> {
+    async fn connect(&self) -> Result<PooledConnection<SqliteConnectionManager>> {
+        let dbm = &*self.state::<SqliteConnection>();
+        let db = dbm.0.lock().await.get()?;
+        Ok(db)
+    }
+}
+
+pub async fn list_workspaces<T: Deref<Target = Connection>>(c: &T) -> Result<Vec<Workspace>> {
+    let (sql, params) = Query::select()
+        .from(WorkspaceIden::Table)
+        .column(Asterisk)
+        .order_by(WorkspaceIden::Name, Order::Asc)
+        .build_rusqlite(SqliteQueryBuilder);
+    let mut stmt = c.prepare(sql.as_str())?;
+    let items = stmt.query_map(&*params.as_params(), |row| row.try_into())?;
+    Ok(items.map(|v| v.unwrap()).collect())
+}

--- a/src-web/components/GrpcConnectionSetupPane.tsx
+++ b/src-web/components/GrpcConnectionSetupPane.tsx
@@ -1,12 +1,11 @@
 import type { GrpcMetadataEntry, GrpcRequest } from '@yaakapp-internal/models';
 import classNames from 'classnames';
-import { useAtom } from 'jotai';
-import { atomWithStorage } from 'jotai/utils';
 import type { CSSProperties } from 'react';
 import React, { useCallback, useMemo, useRef } from 'react';
 import { useContainerSize } from '../hooks/useContainerQuery';
 import type { ReflectResponseService } from '../hooks/useGrpc';
 import { useHttpAuthenticationSummaries } from '../hooks/useHttpAuthentication';
+import { useKeyValue } from '../hooks/useKeyValue';
 import { useRequestUpdateKey } from '../hooks/useRequestUpdateKey';
 import { useUpdateAnyGrpcRequest } from '../hooks/useUpdateAnyGrpcRequest';
 import { resolvedModelName } from '../lib/resolvedModelName';
@@ -52,8 +51,6 @@ const TAB_METADATA = 'metadata';
 const TAB_AUTH = 'auth';
 const TAB_DESCRIPTION = 'description';
 
-const tabsAtom = atomWithStorage<Record<string, string>>('grpcRequestPaneActiveTabs', {});
-
 export function GrpcConnectionSetupPane({
   style,
   services,
@@ -70,7 +67,11 @@ export function GrpcConnectionSetupPane({
 }: Props) {
   const updateRequest = useUpdateAnyGrpcRequest();
   const authentication = useHttpAuthenticationSummaries();
-  const [activeTabs, setActiveTabs] = useAtom(tabsAtom);
+  const { value: activeTabs, set: setActiveTabs } = useKeyValue<Record<string, string>>({
+    namespace: 'no_sync',
+    key: 'grpcRequestActiveTabs',
+    fallback: {},
+  });
   const { updateKey: forceUpdateKey } = useRequestUpdateKey(activeRequest.id ?? null);
 
   const urlContainerEl = useRef<HTMLDivElement>(null);
@@ -183,8 +184,8 @@ export function GrpcConnectionSetupPane({
 
   const activeTab = activeTabs?.[activeRequest.id];
   const setActiveTab = useCallback(
-    (tab: string) => {
-      setActiveTabs((r) => ({ ...r, [activeRequest.id]: tab }));
+    async (tab: string) => {
+      await setActiveTabs((r) => ({ ...r, [activeRequest.id]: tab }));
     },
     [activeRequest.id, setActiveTabs],
   );


### PR DESCRIPTION
This PR changes DB queries to only use AppHandle instead of Window. Window was used to attach the label to the frontend event, so I moved the label to the `UpdateContext` enum instead. Having access to a Window for any DB modifications was quite a limitation, so now the API is usable from more places