### PR TITLE
Send cookies for introspection

### DIFF
--- a/src-web/lib/sendEphemeralRequest.ts
+++ b/src-web/lib/sendEphemeralRequest.ts
@@ -1,4 +1,5 @@
 import type { HttpRequest, HttpResponse } from '@yaakapp-internal/models';
+import { getActiveCookieJar } from '../hooks/useActiveCookieJar';
 import { invokeCmd } from './tauri';
 
 export async function sendEphemeralRequest(
@@ -7,5 +8,9 @@ export async function sendEphemeralRequest(
 ): Promise<HttpResponse> {
   // Remove some things that we don't want to associate
   const newRequest = { ...request };
-  return invokeCmd('cmd_send_ephemeral_request', { request: newRequest, environmentId });
+  return invokeCmd('cmd_send_ephemeral_request', {
+    request: newRequest,
+    environmentId,
+    cookieJarId: getActiveCookieJar()?.id,
+  });
 }


### PR DESCRIPTION
Introspection can require authentication too, so we should send cookies just like we do for normal requests.