### PR TITLE
Allow building and running on aarch64 Linux

### DIFF
--- a/scripts/vendor-node.cjs
+++ b/scripts/vendor-node.cjs
@@ -9,12 +9,14 @@ const NODE_VERSION = 'v22.9.0';
 // `${process.platform}_${process.arch}`
 const MAC_ARM = 'darwin_arm64';
 const MAC_X64 = 'darwin_x64';
+const LNX_ARM = 'linux_arm64';
 const LNX_X64 = 'linux_x64';
 const WIN_X64 = 'win32_x64';
 
 const URL_MAP = {
   [MAC_ARM]: `https://nodejs.org/download/release/${NODE_VERSION}/node-${NODE_VERSION}-darwin-arm64.tar.gz`,
   [MAC_X64]: `https://nodejs.org/download/release/${NODE_VERSION}/node-${NODE_VERSION}-darwin-x64.tar.gz`,
+  [LNX_ARM]: `https://nodejs.org/download/release/${NODE_VERSION}/node-${NODE_VERSION}-linux-arm64.tar.gz`,
   [LNX_X64]: `https://nodejs.org/download/release/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz`,
   [WIN_X64]: `https://nodejs.org/download/release/${NODE_VERSION}/node-${NODE_VERSION}-win-x64.zip`,
 };
@@ -22,15 +24,17 @@ const URL_MAP = {
 const SRC_BIN_MAP = {
   [MAC_ARM]: `node-${NODE_VERSION}-darwin-arm64/bin/node`,
   [MAC_X64]: `node-${NODE_VERSION}-darwin-x64/bin/node`,
+  [LNX_ARM]: `node-${NODE_VERSION}-linux-arm64/bin/node`,
   [LNX_X64]: `node-${NODE_VERSION}-linux-x64/bin/node`,
   [WIN_X64]: `node-${NODE_VERSION}-win-x64/node.exe`,
 };
 
 const DST_BIN_MAP = {
-  darwin_arm64: 'yaaknode-aarch64-apple-darwin',
-  darwin_x64: 'yaaknode-x86_64-apple-darwin',
-  linux_x64: 'yaaknode-x86_64-unknown-linux-gnu',
-  win32_x64: 'yaaknode-x86_64-pc-windows-msvc.exe',
+  [MAC_ARM]: 'yaaknode-aarch64-apple-darwin',
+  [MAC_X64]: 'yaaknode-x86_64-apple-darwin',
+  [LNX_ARM]: 'yaaknode-aarch64-unknown-linux-gnu',
+  [LNX_X64]: 'yaaknode-x86_64-unknown-linux-gnu',
+  [WIN_X64]: 'yaaknode-x86_64-pc-windows-msvc.exe',
 };
 
 const key = `${process.platform}_${process.env.YAAK_TARGET_ARCH ?? process.arch}`;

--- a/scripts/vendor-protoc.cjs
+++ b/scripts/vendor-protoc.cjs
@@ -9,12 +9,14 @@ const VERSION = '28.3';
 // `${process.platform}_${process.arch}`
 const MAC_ARM = 'darwin_arm64';
 const MAC_X64 = 'darwin_x64';
+const LNX_ARM = 'linux_arm64';
 const LNX_X64 = 'linux_x64';
 const WIN_X64 = 'win32_x64';
 
 const URL_MAP = {
   [MAC_ARM]: `https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-osx-aarch_64.zip`,
   [MAC_X64]: `https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-osx-x86_64.zip`,
+  [LNX_ARM]: `https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-linux-aarch_64.zip`,
   [LNX_X64]: `https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-linux-x86_64.zip`,
   [WIN_X64]: `https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-win64.zip`,
 };
@@ -22,6 +24,7 @@ const URL_MAP = {
 const SRC_BIN_MAP = {
   [MAC_ARM]: 'bin/protoc',
   [MAC_X64]: 'bin/protoc',
+  [LNX_ARM]: 'bin/protoc',
   [LNX_X64]: 'bin/protoc',
   [WIN_X64]: 'bin/protoc.exe',
 };
@@ -29,6 +32,7 @@ const SRC_BIN_MAP = {
 const DST_BIN_MAP = {
   [MAC_ARM]: 'yaakprotoc-aarch64-apple-darwin',
   [MAC_X64]: 'yaakprotoc-x86_64-apple-darwin',
+  [LNX_ARM]: 'yaakprotoc-aarch64-unknown-linux-gnu',
   [LNX_X64]: 'yaakprotoc-x86_64-unknown-linux-gnu',
   [WIN_X64]: 'yaakprotoc-x86_64-pc-windows-msvc.exe',
 };


### PR DESCRIPTION
This PR updates the vendor script to download aarch64 linux artifacts, allowing Yaak to be developed/run/built on aarch64 Linux platforms.