### PR TITLE
fix: change incorrect default GraphQL request name

### DIFF
--- a/src-web/lib/resolvedModelName.ts
+++ b/src-web/lib/resolvedModelName.ts
@@ -18,7 +18,9 @@ export function resolvedModelName(r: AnyModel | null): string {
   const withoutVariables = r.url.replace(/\$\{\[\s*([^\]\s]+)\s*]}/g, '$1');
   if (withoutVariables.trim() === '') {
     return r.model === 'http_request'
-      ? 'HTTP Request'
+      ? r.bodyType && r.bodyType === 'graphql'
+        ? 'GraphQL Request'
+        : 'HTTP Request'
       : r.model === 'websocket_request'
         ? 'WebSocket Request'
         : 'gRPC Request';


### PR DESCRIPTION
Default GraphQL request name is `HTTP Request` which seem incorrect. This pull request change it from `HTTP Request` to `GraphQL Request`.

previous:
![SCR-20250523-rvfd](https://github.com/user-attachments/assets/bc7c20fc-5efc-43f5-b889-28853c3ce4a5)


updated:

![SCR-20250523-ruzo](https://github.com/user-attachments/assets/93064419-06a3-4552-8a55-5dc081123301)

edited: `GraphQL` Request -> `GraphQL Request`