### PR TITLE
Fix infinite recursion in GraphQL docs explorer when handling circular type references

### DIFF
--- a/src-web/components/GraphQLDocsExplorer.tsx
+++ b/src-web/components/GraphQLDocsExplorer.tsx
@@ -45,8 +45,16 @@ function getTypeIndices(
     return indices;
   }
 
+  const typeName = (type as GraphQLObjectType).name;
+
+  if (context.visitedTypes.has(typeName)) {
+    return indices;
+  }
+
+  context.visitedTypes.add(typeName);
+
   indices.push({
-    name: (type as GraphQLObjectType).name,
+    name: typeName,
     type: 'type',
     schemaPointer: type,
     args: '',
@@ -107,6 +115,7 @@ type SearchIndexRecord = {
 
 type IndexGenerationContext = {
   rootType: 'Query' | 'Mutation' | 'Subscription';
+  visitedTypes: Set<string>;
 };
 
 type SchemaPointer = Field | GraphQLOutputType | GraphQLInputType | null;
@@ -147,6 +156,7 @@ function DocsExplorer({ graphqlSchema }: { graphqlSchema: GraphQLSchema }) {
       index.push(
         ...getFieldsIndices(type.getFields(), {
           rootType: type.name as IndexGenerationContext['rootType'],
+          visitedTypes: new Set<string>(),
         }),
       );
     });


### PR DESCRIPTION
## Problem
The GraphQL docs explorer was throwing "Maximum call stack size exceeded" errors due to infinite recursion when processing GraphQL schemas with circular type references.

## Root Cause
The `getFieldsIndices` and `getTypeIndices` functions were calling each other recursively without checking for already-processed types:
- `getFieldsIndices` processes fields and calls `getTypeIndices` for each field's type
- `getTypeIndices` processes types and calls `getFieldsIndices` for the type's fields
- When schemas contain circular references (Type A → Type B → Type A), this creates infinite recursion

## Solution
Added a visited set to track which types have been processed:
- Added `visitedTypes: Set<string>` to `IndexGenerationContext`
- Check if a type has already been visited before processing it
- Mark types as visited when starting to process them
- Initialize a new visited set for each root type processing
