### PR TITLE
Fix duplicated character when composing text

### DIFF
--- a/src-web/components/core/Editor/singleLine.ts
+++ b/src-web/components/core/Editor/singleLine.ts
@@ -6,6 +6,9 @@ export function singleLineExtensions(): Extension {
     (tr: Transaction): TransactionSpec | TransactionSpec[] => {
       if (!tr.isUserEvent('input')) return tr;
 
+      // when composing text via IME, return
+      if (tr.isUserEvent('input.type.compose')) return tr;
+
       const specs: TransactionSpec[] = [];
       tr.changes.iterChanges((_, toA, fromB, toB, inserted) => {
         let insert = '';


### PR DESCRIPTION
fix feedback: https://feedback.yaak.app/p/input-text-duplicated-when-using-chinese-input-method-in-macos-2
related: #215 