### PR TITLE
remove unnecessary semicolon in tailwind config file

### DIFF
--- a/src-web/tailwind.config.cjs
+++ b/src-web/tailwind.config.cjs
@@ -93,7 +93,7 @@ module.exports = {
       shrink: '0.8em',
     },
     boxShadow: {
-      DEFAULT: '0 1px 3px 0 var(--shadow);',
+      DEFAULT: '0 1px 3px 0 var(--shadow)',
       lg: '0 10px 15px -3px var(--shadow)',
     },
     colors: {


### PR DESCRIPTION
Fix this warn

```
rendering chunks (5)...[esbuild css minify]
▲ [WARNING] Expected identifier but found "!" [css-syntax-error]

    <stdin>:2090:42:
      2090 │   --tw-shadow: 0 1px 3px 0 var(--shadow); !important;
           ╵                                           ^
```