### PR TITLE
make monospace font family follows app setting in auto completion menu

### DIFF
--- a/src-web/components/core/Editor/Editor.css
+++ b/src-web/components/core/Editor/Editor.css
@@ -257,6 +257,10 @@
 .cm-tooltip.cm-completionInfo {
   @apply shadow-lg bg-surface rounded text-text-subtle border border-border-subtle z-50 pointer-events-auto text-editor;
 
+  & * {
+    @apply font-mono;
+  }
+
   .cm-completionIcon {
     @apply font-mono opacity-80 italic;
 

--- a/src-web/components/core/Editor/Editor.css
+++ b/src-web/components/core/Editor/Editor.css
@@ -255,14 +255,14 @@
 /* NOTE: Extra selector required to override default styles */
 .cm-tooltip.cm-tooltip-autocomplete,
 .cm-tooltip.cm-completionInfo {
-  @apply shadow-lg bg-surface rounded text-text-subtle border border-border-subtle z-50 pointer-events-auto text-editor;
+  @apply shadow-lg bg-surface rounded text-text-subtle border border-border-subtle z-50 pointer-events-auto;
 
   & * {
-    @apply font-mono;
+    @apply font-mono text-editor !important;
   }
 
   .cm-completionIcon {
-    @apply font-mono opacity-80 italic;
+    @apply opacity-80 italic;
 
     &::after {
       content: 'a' !important; /* Default (eg. for GraphQL) */


### PR DESCRIPTION
Fix this inconsistent issue
<img width="530" height="602" alt="PixPin_2025-07-17_22-18-11" src="https://github.com/user-attachments/assets/dd39c8e3-1a10-47f6-9d06-246edbb51561" />
