### PR TITLE
add `template-function-datetime`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "plugins/importer-postman",
         "plugins/importer-yaak",
         "plugins/template-function-cookie",
+        "plugins/template-function-datetime",
         "plugins/template-function-encode",
         "plugins/template-function-fs",
         "plugins/template-function-hash",
@@ -4135,6 +4136,10 @@
     },
     "node_modules/@yaak/template-function-cookie": {
       "resolved": "plugins/template-function-cookie",
+      "link": true
+    },
+    "node_modules/@yaak/template-function-datetime": {
+      "resolved": "plugins/template-function-datetime",
       "link": true
     },
     "node_modules/@yaak/template-function-encode": {
@@ -18575,6 +18580,12 @@
     "plugins/template-function-cookie": {
       "name": "@yaak/template-function-cookie",
       "version": "0.1.0"
+    },
+    "plugins/template-function-datetime": {
+      "version": "0.1.0",
+      "dependencies": {
+        "date-fns": "^4.1.0"
+      }
     },
     "plugins/template-function-encode": {
       "name": "@yaak/template-function-encode",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "plugins/importer-postman",
     "plugins/importer-yaak",
     "plugins/template-function-cookie",
+    "plugins/template-function-datetime",
     "plugins/template-function-encode",
     "plugins/template-function-fs",
     "plugins/template-function-hash",

--- a/plugins/template-function-datetime/package.json
+++ b/plugins/template-function-datetime/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@yaak/template-function-datetime",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "build": "yaakcli build",
+    "dev": "yaakcli dev",
+    "lint": "eslint . --ext .ts,.tsx"
+  },
+  "dependencies": {
+    "date-fns": "^4.1.0"
+  }
+}

--- a/plugins/template-function-datetime/src/index.ts
+++ b/plugins/template-function-datetime/src/index.ts
@@ -1,0 +1,186 @@
+import type { PluginDefinition } from '@yaakapp/api';
+
+import {
+  addDays,
+  addMonths,
+  addYears,
+  addHours,
+  addMinutes,
+  addSeconds,
+  subDays,
+  subMonths,
+  subYears,
+  subHours,
+  subMinutes,
+  subSeconds,
+  format,
+  parseISO,
+  isValid,
+} from 'date-fns';
+
+function applyDateOp(d: Date, sign: string, amount: number, unit: string): Date {
+  switch (unit) {
+    case 'y':
+      return sign === '-' ? subYears(d, amount) : addYears(d, amount);
+    case 'M':
+      return sign === '-' ? subMonths(d, amount) : addMonths(d, amount);
+    case 'd':
+      return sign === '-' ? subDays(d, amount) : addDays(d, amount);
+    case 'h':
+      return sign === '-' ? subHours(d, amount) : addHours(d, amount);
+    case 'm':
+      return sign === '-' ? subMinutes(d, amount) : addMinutes(d, amount);
+    case 's':
+      return sign === '-' ? subSeconds(d, amount) : addSeconds(d, amount);
+    default:
+      throw new Error(`Invalid unit: ${unit}`);
+  }
+}
+
+function parseOp(op: string): { sign: string; amount: number; unit: string } | null {
+  const match = op.match(/^([+-])(\d+)([a-zA-Z]+)$/);
+  if (!match) return null;
+  const [, sign, amount, unit] = match;
+  if (!unit) return null;
+  if (!['y', 'M', 'd', 'h', 'm', 's'].includes(unit)) {
+    throw new Error(`Invalid unit: ${unit}`);
+  }
+  return { sign: sign ?? '+', amount: Number(amount ?? 0), unit };
+}
+
+export async function calculateDatetime(args: {
+  date?: string;
+  calc?: string;
+}): Promise<string> {
+  const { date, calc } = args;
+  let d: Date;
+  if (date) {
+    if (/^\d+$/.test(date)) {
+      d = new Date(Number(date));
+    } else {
+      d = parseISO(date);
+      if (!isValid(d)) d = new Date(date);
+    }
+  } else {
+    d = new Date();
+  }
+  if (calc) {
+    const ops = String(calc)
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    for (const op of ops) {
+      const parsed = parseOp(op);
+      if (parsed) {
+        d = applyDateOp(d, parsed.sign, parsed.amount, parsed.unit);
+      }
+    }
+  }
+  return d.toISOString();
+}
+
+export async function formatDatetime(args: {
+  date?: string;
+  output?: string;
+}): Promise<string> {
+  const { date, output = 'yyyy-MM-dd HH:mm:ss' } = args;
+  let d: Date;
+  if (date) {
+    if (/^\d+$/.test(date)) {
+      d = new Date(Number(date));
+    } else {
+      d = parseISO(date);
+      if (!isValid(d)) d = new Date(date);
+    }
+  } else {
+    d = new Date();
+  }
+  return format(d, String(output));
+}
+
+export const plugin: PluginDefinition = {
+  templateFunctions: [
+    {
+      name: 'datetime.timestamp',
+      description: 'Get the current timestamp in milliseconds',
+      args: [],
+      onRender: async () => String(Date.now()),
+    },
+    {
+      name: 'datetime.iso',
+      description: 'Get the current date in ISO format',
+      args: [],
+      onRender: async () => new Date().toISOString(),
+    },
+    {
+      name: 'datetime.calculate',
+      description: 'Manipulate the datetime, returns ISO string. Input is optional, default to current datetime.',
+      args: [
+        {
+          name: 'date',
+          label: 'Date String',
+          description: 'The date to manipulate, can be a timestamp or ISO string',
+          type: 'text',
+          optional: true,
+          placeholder: 'Default: current date',
+        },
+        {
+          name: 'calc',
+          label: 'Calculate Expression',
+          description: "The calculate expression in dayjs format, split by commas: '-5d, +2h, 3m'. Available units: y, M, d, h, m, s",
+          optional: true,
+          placeholder: 'Example: -5d, +2h, 3m',
+          type: 'text',
+        },
+      ],
+      onRender: async ({toast}, args) => {
+        try {
+          return await calculateDatetime(args.values);
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          toast.show({
+            icon: 'alert_triangle',
+            color: 'warning',
+            message:`Error calculating date: ${msg}`
+          });
+          return null;
+        }
+      },
+    },
+    {
+      name: 'datetime.format',
+      description: 'Format a date using a specified format string. Input is optional, default to current datetime.',
+      args: [
+        {
+          name: 'date',
+          label: 'Date String',
+          description: 'The date to format, can be a timestamp or ISO string',
+          type: 'text',
+          optional: true,
+          placeholder: 'Default: current date',
+        },
+        {
+          name: 'output',
+          label: 'Output Format String',
+          description: "The output format string in dayjs format, e.g., 'YYYY-MM-DD HH:mm:ss'",
+          optional: true,
+          placeholder: 'Default: YYYY-MM-DD HH:mm:ss',
+          type: 'text',
+        },
+      ],
+      onRender: async ({toast}, args) => {
+        try {
+          return await formatDatetime(args.values);
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          toast.show({
+            icon: 'alert_triangle',
+            color: 'warning',
+            message:`Error formatting date: ${msg}`
+          });
+          return null;
+        }
+      },
+    },
+  ],
+};

--- a/plugins/template-function-datetime/tests/formatDatetime.test.ts
+++ b/plugins/template-function-datetime/tests/formatDatetime.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { formatDatetime, calculateDatetime } from '../src/index';
+
+describe('formatDatetime', () => {
+  it('returns formatted current date', async () => {
+    const result = await formatDatetime({});
+    expect(result).toMatch(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/);
+  });
+
+  it('returns formatted specific date', async () => {
+    const result = await formatDatetime({ date: '2025-07-13T12:34:56' });
+    expect(result).toBe('2025-07-13 12:34:56');
+  });
+
+  it('returns formatted date with custom output', async () => {
+    const result = await formatDatetime({ date: '2025-07-13T12:34:56', output: 'dd/MM/yyyy' });
+    expect(result).toBe('13/07/2025');
+  });
+
+  it('handles invalid date gracefully', async () => {
+    await expect(formatDatetime({ date: 'invalid-date' })).rejects.toThrow('Invalid time value');
+  });
+});
+
+describe('calculateDatetime', () => {
+  it('returns ISO string for current date', async () => {
+    const result = await calculateDatetime({});
+    expect(result).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it('returns ISO string for specific date', async () => {
+    const result = await calculateDatetime({ date: '2025-07-13T12:34:56' });
+    expect(result).toBe('2025-07-13T12:34:56.000Z');
+  });
+
+  it('applies calc operations', async () => {
+    const result = await calculateDatetime({ date: '2025-07-13T12:00:00', calc: '+1d,+2h' });
+    expect(result).toBe('2025-07-14T14:00:00.000Z');
+  });
+
+  it('applies negative calc operations', async () => {
+    const result = await calculateDatetime({ date: '2025-07-13T12:00:00', calc: '-1d,-2h' });
+    expect(result).toBe('2025-07-12T10:00:00.000Z');
+  });
+
+  it('throws error for invalid unit', async () => {
+    await expect(calculateDatetime({ date: '2025-07-13T12:00:00', calc: '+1x' })).rejects.toThrow('Invalid unit: x');
+  });
+});

--- a/plugins/template-function-datetime/tsconfig.json
+++ b/plugins/template-function-datetime/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}


### PR DESCRIPTION
In this PR, I added 4 template functions for datetime with `date-fns`:

- `datetime.timestamp`: Returns current timestamp in milliseconds.
- `datetime.iso`: Returns current date in ISO format.
- `datetime.calculate`: Supports date arithmetic (e.g., `+1d,-2h`) and returns ISO string.
- `datetime.format`: Formats a date string with a custom output format.