### PR TITLE
[plugin/oauth2] Support identity platforms with underlying IDSs

### DIFF
--- a/plugins/auth-oauth2/src/grants/authorizationCode.ts
+++ b/plugins/auth-oauth2/src/grants/authorizationCode.ts
@@ -100,6 +100,11 @@ export async function getAuthorizationCode(
         const url = new URL(urlStr);
         if (logsEnabled) console.log('[oauth2] Navigated to', urlStr);
 
+        if (redirectUri && !url.toString().startsWith(redirectUri)) {
+          console.log('[oauth2] Current URL does not match redirect URI, not looking for code.');
+          return;
+        }
+
         if (url.searchParams.has('error')) {
           close();
           return reject(new Error(`Failed to authorize: ${url.searchParams.get('error')}`));


### PR DESCRIPTION
When using an identity platform (such as AWS Cognito) authenticating through another IDP (such as Google) with OAuth 2, Yaak's OAuth 2 plugin picks up the code sent from the IDP to the identity platform, rather than that sent by the identity platform to Yaak.

By checking that the current navigation URL matches the provided redirect URI, we can make sure to use only the code intended for Yaak, no matter how many OAuth 2 loops there might be.