### PR TITLE
Add OpenAPI URL import and manual resync

### DIFF
--- a/crates-tauri/yaak-app/src/import.rs
+++ b/crates-tauri/yaak-app/src/import.rs
@@ -1,39 +1,114 @@
 use crate::PluginContextExt;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::models_ext::QueryManagerExt;
+use chrono::Utc;
 use log::info;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::read_to_string;
 use tauri::{Manager, Runtime, WebviewWindow};
+use url::Url;
+use yaak_api::{ApiClientKind, yaak_api_client};
 use yaak_core::WorkspaceContext;
 use yaak_models::models::{
-    Environment, Folder, GrpcRequest, HttpRequest, WebsocketRequest, Workspace,
+    Environment, Folder, GrpcRequest, HttpRequest, WebsocketRequest, Workspace, WorkspaceMeta,
 };
 use yaak_models::util::{BatchUpsertResult, UpdateSource, maybe_gen_id, maybe_gen_id_opt};
+use yaak_plugins::events::ImportResources;
 use yaak_plugins::manager::PluginManager;
 use yaak_tauri_utils::window::WorkspaceWindowTrait;
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+struct RequestMatchKey {
+    folder_path: Vec<String>,
+    method: String,
+    url_path: String,
+}
 
 pub(crate) async fn import_data<R: Runtime>(
     window: &WebviewWindow<R>,
     file_path: &str,
 ) -> Result<BatchUpsertResult> {
+    let file_contents = read_to_string(file_path)?;
+    let resources = import_resources(window, file_contents.as_str()).await?;
+    upsert_import_resources(window, resources)
+}
+
+pub(crate) async fn import_openapi_url<R: Runtime>(
+    window: &WebviewWindow<R>,
+    url: &str,
+    target_workspace_id: Option<&str>,
+) -> Result<BatchUpsertResult> {
+    let contents = fetch_url(window, url).await?;
+    let resources = import_resources(window, contents.as_str()).await?;
+    let resources = match target_workspace_id {
+        Some(workspace_id) => retarget_import_resources(
+            resources,
+            workspace_id,
+            &window.db().list_folders(workspace_id)?,
+            &window.db().list_http_requests(workspace_id)?,
+        ),
+        None => resources,
+    };
+    let upserted = upsert_import_resources(window, resources)?;
+
+    let workspace_id = target_workspace_id
+        .map(str::to_string)
+        .or_else(|| upserted.workspaces.first().map(|w| w.id.clone()))
+        .ok_or_else(|| Error::GenericError("OpenAPI import did not create a workspace".to_string()))?;
+
+    upsert_openapi_workspace_meta(window, workspace_id.as_str(), url)?;
+
+    Ok(upserted)
+}
+
+async fn fetch_url<R: Runtime>(window: &WebviewWindow<R>, url: &str) -> Result<String> {
+    let app_version = window.app_handle().package_info().version.to_string();
+    let response = yaak_api_client(ApiClientKind::App, &app_version)?
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?;
+    Ok(response.text().await?)
+}
+
+async fn import_resources<R: Runtime>(
+    window: &WebviewWindow<R>,
+    contents: &str,
+) -> Result<ImportResources> {
     let plugin_manager = window.state::<PluginManager>();
-    let file =
-        read_to_string(file_path).unwrap_or_else(|_| panic!("Unable to read file {}", file_path));
-    let file_contents = file.as_str();
-    let import_result = plugin_manager.import_data(&window.plugin_context(), file_contents).await?;
+    let import_result = plugin_manager.import_data(&window.plugin_context(), contents).await?;
+    Ok(import_result.resources)
+}
 
+fn upsert_openapi_workspace_meta<R: Runtime>(
+    window: &WebviewWindow<R>,
+    workspace_id: &str,
+    url: &str,
+) -> Result<()> {
+    let db = window.db();
+    let workspace_meta = db.get_or_create_workspace_meta(workspace_id)?;
+    db.upsert_workspace_meta(
+        &WorkspaceMeta {
+            openapi_import_url: Some(url.to_string()),
+            openapi_last_synced_at: Some(Utc::now().naive_utc()),
+            ..workspace_meta
+        },
+        &UpdateSource::Import,
+    )?;
+    Ok(())
+}
+
+fn upsert_import_resources<R: Runtime>(
+    window: &WebviewWindow<R>,
+    resources: ImportResources,
+) -> Result<BatchUpsertResult> {
     let mut id_map: BTreeMap<String, String> = BTreeMap::new();
-
-    // Create WorkspaceContext from window
     let ctx = WorkspaceContext {
         workspace_id: window.workspace_id(),
         environment_id: window.environment_id(),
         cookie_jar_id: window.cookie_jar_id(),
         request_id: None,
     };
-
-    let resources = import_result.resources;
 
     let workspaces: Vec<Workspace> = resources
         .workspaces
@@ -52,14 +127,12 @@ pub(crate) async fn import_data<R: Runtime>(
             v.workspace_id = maybe_gen_id::<Workspace>(&ctx, v.workspace_id.as_str(), &mut id_map);
             match (v.parent_model.as_str(), v.parent_id.clone().as_deref()) {
                 ("folder", Some(parent_id)) => {
-                    v.parent_id = Some(maybe_gen_id::<Folder>(&ctx, &parent_id, &mut id_map));
+                    v.parent_id = Some(maybe_gen_id::<Folder>(&ctx, parent_id, &mut id_map));
                 }
                 ("", _) => {
-                    // Fix any empty ones
                     v.parent_model = "workspace".to_string();
                 }
                 _ => {
-                    // Parent ID only required for the folder case
                     v.parent_id = None;
                 }
             };
@@ -113,7 +186,7 @@ pub(crate) async fn import_data<R: Runtime>(
 
     info!("Importing data");
 
-    let upserted = window.with_tx(|tx| {
+    Ok(window.with_tx(|tx| {
         tx.batch_upsert(
             workspaces,
             environments,
@@ -123,7 +196,340 @@ pub(crate) async fn import_data<R: Runtime>(
             websocket_requests,
             &UpdateSource::Import,
         )
-    })?;
+    })?)
+}
 
-    Ok(upserted)
+fn retarget_import_resources(
+    mut resources: ImportResources,
+    target_workspace_id: &str,
+    existing_folders: &[Folder],
+    existing_http_requests: &[HttpRequest],
+) -> ImportResources {
+    let imported_folder_paths = build_folder_paths(&resources.folders);
+    let existing_folder_paths = build_folder_paths(existing_folders);
+    let existing_folders_by_path: HashMap<Vec<String>, Folder> = existing_folders
+        .iter()
+        .filter_map(|folder| {
+            existing_folder_paths
+                .get(folder.id.as_str())
+                .map(|path| (path.clone(), folder.clone()))
+        })
+        .collect();
+    let existing_http_requests_by_key = build_http_request_map(
+        existing_http_requests,
+        &existing_folder_paths,
+    );
+
+    let mut folder_id_map: HashMap<String, String> = HashMap::new();
+    let mut folders = Vec::new();
+    for mut folder in std::mem::take(&mut resources.folders) {
+        let original_id = folder.id.clone();
+        let path = imported_folder_paths.get(original_id.as_str()).cloned().unwrap_or_default();
+
+        if let Some(existing_folder) = existing_folders_by_path.get(&path) {
+            folder_id_map.insert(original_id, existing_folder.id.clone());
+            continue;
+        }
+
+        folder.workspace_id = target_workspace_id.to_string();
+        folder.folder_id = folder
+            .folder_id
+            .as_ref()
+            .and_then(|id| folder_id_map.get(id))
+            .cloned();
+        folder_id_map.insert(original_id, folder.id.clone());
+        folders.push(folder);
+    }
+
+    let mut http_requests = Vec::new();
+    for mut request in std::mem::take(&mut resources.http_requests) {
+        let folder_path = request
+            .folder_id
+            .as_ref()
+            .and_then(|id| imported_folder_paths.get(id))
+            .cloned()
+            .unwrap_or_default();
+        let key = RequestMatchKey {
+            folder_path,
+            method: request.method.to_ascii_uppercase(),
+            url_path: normalize_url_path(request.url.as_str()),
+        };
+
+        request.workspace_id = target_workspace_id.to_string();
+
+        if let Some(existing_request) = existing_http_requests_by_key.get(&key) {
+            request.id = existing_request.id.clone();
+            request.folder_id = existing_request.folder_id.clone();
+            request.name = existing_request.name.clone();
+            request.headers = existing_request.headers.clone();
+            request.body = existing_request.body.clone();
+            request.body_type = existing_request.body_type.clone();
+            request.authentication = existing_request.authentication.clone();
+            request.authentication_type = existing_request.authentication_type.clone();
+            request.sort_priority = existing_request.sort_priority;
+        } else {
+            request.folder_id = request
+                .folder_id
+                .as_ref()
+                .and_then(|id| folder_id_map.get(id))
+                .cloned();
+        }
+
+        http_requests.push(request);
+    }
+
+    for request in &mut resources.grpc_requests {
+        request.workspace_id = target_workspace_id.to_string();
+        request.folder_id = request
+            .folder_id
+            .as_ref()
+            .and_then(|id| folder_id_map.get(id))
+            .cloned();
+    }
+
+    for request in &mut resources.websocket_requests {
+        request.workspace_id = target_workspace_id.to_string();
+        request.folder_id = request
+            .folder_id
+            .as_ref()
+            .and_then(|id| folder_id_map.get(id))
+            .cloned();
+    }
+
+    resources.workspaces.clear();
+    resources.environments.clear();
+    resources.folders = folders;
+    resources.http_requests = http_requests;
+    resources
+}
+
+fn build_http_request_map(
+    requests: &[HttpRequest],
+    folder_paths: &HashMap<String, Vec<String>>,
+) -> HashMap<RequestMatchKey, HttpRequest> {
+    let mut map = HashMap::new();
+
+    for request in requests {
+        let folder_path = request
+            .folder_id
+            .as_ref()
+            .and_then(|id| folder_paths.get(id))
+            .cloned()
+            .unwrap_or_default();
+        let key = RequestMatchKey {
+            folder_path,
+            method: request.method.to_ascii_uppercase(),
+            url_path: normalize_url_path(request.url.as_str()),
+        };
+        map.entry(key).or_insert_with(|| request.clone());
+    }
+
+    map
+}
+
+fn build_folder_paths(folders: &[Folder]) -> HashMap<String, Vec<String>> {
+    let folders_by_id: HashMap<&str, &Folder> =
+        folders.iter().map(|folder| (folder.id.as_str(), folder)).collect();
+    let mut paths = HashMap::new();
+
+    for folder in folders {
+        let _ = build_folder_path(folder.id.as_str(), &folders_by_id, &mut paths);
+    }
+
+    paths
+}
+
+fn build_folder_path(
+    folder_id: &str,
+    folders_by_id: &HashMap<&str, &Folder>,
+    paths: &mut HashMap<String, Vec<String>>,
+) -> Vec<String> {
+    if let Some(path) = paths.get(folder_id) {
+        return path.clone();
+    }
+
+    let Some(folder) = folders_by_id.get(folder_id) else {
+        return Vec::new();
+    };
+
+    let mut path = folder
+        .folder_id
+        .as_deref()
+        .map(|parent_id| build_folder_path(parent_id, folders_by_id, paths))
+        .unwrap_or_default();
+    path.push(folder.name.clone());
+    paths.insert(folder_id.to_string(), path.clone());
+    path
+}
+
+fn normalize_url_path(url: &str) -> String {
+    let without_fragment = url.split_once('#').map(|(v, _)| v).unwrap_or(url);
+    let base = without_fragment
+        .split_once('?')
+        .map(|(v, _)| v)
+        .unwrap_or(without_fragment);
+
+    let path = Url::parse(base)
+        .ok()
+        .map(|u| u.path().to_string())
+        .or_else(|| extract_path(base))
+        .unwrap_or_else(|| "/".to_string());
+
+    let normalized_segments: Vec<String> = path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .map(normalize_path_segment)
+        .collect();
+
+    if normalized_segments.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{}", normalized_segments.join("/"))
+    }
+}
+
+fn extract_path(url: &str) -> Option<String> {
+    if url.starts_with('/') {
+        return Some(url.to_string());
+    }
+
+    let after_scheme = url
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(url);
+    let slash_idx = after_scheme.find('/')?;
+    Some(after_scheme[slash_idx..].to_string())
+}
+
+fn normalize_path_segment(segment: &str) -> String {
+    if segment.starts_with(':') {
+        return "{param}".to_string();
+    }
+
+    if segment.starts_with('{') && segment.ends_with('}') {
+        return "{param}".to_string();
+    }
+
+    let lower = segment.to_ascii_lowercase();
+    if lower.starts_with("%7b") && lower.ends_with("%7d") {
+        return "{param}".to_string();
+    }
+
+    segment.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_url_path, retarget_import_resources};
+    use yaak_models::models::{Folder, HttpRequest};
+    use yaak_plugins::events::ImportResources;
+
+    #[test]
+    fn normalizes_openapi_path_templates() {
+        assert_eq!(
+            normalize_url_path("https://api.example.com/pets/{id}?include=owner"),
+            "/pets/{param}"
+        );
+        assert_eq!(normalize_url_path("${[baseUrl]}/pets/:id"), "/pets/{param}");
+        assert_eq!(normalize_url_path("/pets/{id}"), "/pets/{param}");
+    }
+
+    #[test]
+    fn resync_reuses_existing_ids_and_only_keeps_new_resources() {
+        let target_workspace_id = "wk_existing";
+        let existing_folders = vec![Folder {
+            id: "fl_pets".to_string(),
+            workspace_id: target_workspace_id.to_string(),
+            name: "Pets".to_string(),
+            ..Default::default()
+        }];
+        let existing_http_requests = vec![HttpRequest {
+            id: "rq_list_pets".to_string(),
+            workspace_id: target_workspace_id.to_string(),
+            folder_id: Some("fl_pets".to_string()),
+            name: "Custom list pets".to_string(),
+            method: "GET".to_string(),
+            url: "https://api.example.com/pets".to_string(),
+            description: "old".to_string(),
+            headers: vec![Default::default()],
+            body_type: Some("application/json".to_string()),
+            sort_priority: 9.0,
+            ..Default::default()
+        }];
+        let resources = ImportResources {
+            workspaces: vec![Default::default()],
+            environments: vec![Default::default()],
+            folders: vec![
+                Folder {
+                    id: "GENERATE_ID::FOLDER_0".to_string(),
+                    workspace_id: "GENERATE_ID::WORKSPACE_0".to_string(),
+                    name: "Pets".to_string(),
+                    ..Default::default()
+                },
+                Folder {
+                    id: "GENERATE_ID::FOLDER_1".to_string(),
+                    workspace_id: "GENERATE_ID::WORKSPACE_0".to_string(),
+                    name: "Admin".to_string(),
+                    ..Default::default()
+                },
+            ],
+            http_requests: vec![
+                HttpRequest {
+                    id: "GENERATE_ID::HTTP_REQUEST_0".to_string(),
+                    workspace_id: "GENERATE_ID::WORKSPACE_0".to_string(),
+                    folder_id: Some("GENERATE_ID::FOLDER_0".to_string()),
+                    name: "List pets".to_string(),
+                    method: "GET".to_string(),
+                    url: "https://api.example.com/pets".to_string(),
+                    description: "fresh".to_string(),
+                    ..Default::default()
+                },
+                HttpRequest {
+                    id: "GENERATE_ID::HTTP_REQUEST_1".to_string(),
+                    workspace_id: "GENERATE_ID::WORKSPACE_0".to_string(),
+                    folder_id: Some("GENERATE_ID::FOLDER_1".to_string()),
+                    name: "List admins".to_string(),
+                    method: "GET".to_string(),
+                    url: "https://api.example.com/admins".to_string(),
+                    description: "new".to_string(),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let retargeted = retarget_import_resources(
+            resources,
+            target_workspace_id,
+            &existing_folders,
+            &existing_http_requests,
+        );
+
+        assert!(retargeted.workspaces.is_empty());
+        assert!(retargeted.environments.is_empty());
+        assert_eq!(retargeted.folders.len(), 1);
+        assert_eq!(retargeted.folders[0].name, "Admin");
+        assert_eq!(retargeted.folders[0].workspace_id, target_workspace_id);
+
+        assert_eq!(retargeted.http_requests.len(), 2);
+
+        let updated_request = retargeted
+            .http_requests
+            .iter()
+            .find(|r| r.id == "rq_list_pets")
+            .expect("expected existing request to be reused");
+        assert_eq!(updated_request.description, "fresh");
+        assert_eq!(updated_request.name, "Custom list pets");
+        assert_eq!(updated_request.headers.len(), 1);
+        assert_eq!(updated_request.body_type.as_deref(), Some("application/json"));
+        assert_eq!(updated_request.sort_priority, 9.0);
+
+        let new_request = retargeted
+            .http_requests
+            .iter()
+            .find(|r| r.name == "List admins")
+            .expect("expected new request to be kept");
+        assert_eq!(new_request.workspace_id, target_workspace_id);
+        assert_eq!(new_request.folder_id.as_deref(), Some("GENERATE_ID::FOLDER_1"));
+    }
 }

--- a/crates-tauri/yaak-app/src/lib.rs
+++ b/crates-tauri/yaak-app/src/lib.rs
@@ -4,7 +4,7 @@ use crate::error::Error::GenericError;
 use crate::error::Result;
 use crate::grpc::{build_metadata, metadata_to_map, resolve_grpc_request};
 use crate::http_request::{resolve_http_request, send_http_request};
-use crate::import::import_data;
+use crate::import::{import_data, import_openapi_url};
 use crate::models_ext::{BlobManagerExt, QueryManagerExt};
 use crate::notifications::YaakNotifier;
 use crate::render::{render_grpc_request, render_json_value, render_template};
@@ -970,6 +970,15 @@ async fn cmd_import_data<R: Runtime>(
 }
 
 #[tauri::command]
+async fn cmd_import_openapi_url<R: Runtime>(
+    window: WebviewWindow<R>,
+    url: &str,
+    target_workspace_id: Option<String>,
+) -> YaakResult<BatchUpsertResult> {
+    import_openapi_url(&window, url, target_workspace_id.as_deref()).await
+}
+
+#[tauri::command]
 async fn cmd_http_request_actions<R: Runtime>(
     window: WebviewWindow<R>,
     plugin_manager: State<'_, PluginManager>,
@@ -1663,6 +1672,7 @@ pub fn run() {
             cmd_workspace_actions,
             cmd_folder_actions,
             cmd_import_data,
+            cmd_import_openapi_url,
             cmd_metadata,
             cmd_new_child_window,
             cmd_new_main_window,

--- a/crates/yaak-models/bindings/gen_models.ts
+++ b/crates/yaak-models/bindings/gen_models.ts
@@ -18,7 +18,12 @@ export type EditorKeymap = "default" | "vim" | "vscode" | "emacs";
 
 export type EncryptedKey = { encryptedKey: string, };
 
-export type Environment = { model: "environment", id: string, workspaceId: string, createdAt: string, updatedAt: string, name: string, public: boolean, parentModel: string, parentId: string | null, variables: Array<EnvironmentVariable>, color: string | null, sortPriority: number, };
+export type Environment = { model: "environment", id: string, workspaceId: string, createdAt: string, updatedAt: string, name: string, public: boolean, parentModel: string, parentId: string | null, 
+/**
+ * Variables defined in this environment scope.
+ * Child environments override parent variables by name.
+ */
+variables: Array<EnvironmentVariable>, color: string | null, sortPriority: number, };
 
 export type EnvironmentVariable = { enabled?: boolean, name: string, value: string, id?: string, };
 
@@ -34,9 +39,17 @@ export type GrpcEvent = { model: "grpc_event", id: string, createdAt: string, up
 
 export type GrpcEventType = "info" | "error" | "client_message" | "server_message" | "connection_start" | "connection_end";
 
-export type GrpcRequest = { model: "grpc_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authenticationType: string | null, authentication: Record<string, any>, description: string, message: string, metadata: Array<HttpRequestHeader>, method: string | null, name: string, service: string | null, sortPriority: number, url: string, };
+export type GrpcRequest = { model: "grpc_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authenticationType: string | null, authentication: Record<string, any>, description: string, message: string, metadata: Array<HttpRequestHeader>, method: string | null, name: string, service: string | null, sortPriority: number, 
+/**
+ * Server URL (http for plaintext or https for secure)
+ */
+url: string, };
 
-export type HttpRequest = { model: "http_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, body: Record<string, any>, bodyType: string | null, description: string, headers: Array<HttpRequestHeader>, method: string, name: string, sortPriority: number, url: string, urlParameters: Array<HttpUrlParameter>, };
+export type HttpRequest = { model: "http_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, body: Record<string, any>, bodyType: string | null, description: string, headers: Array<HttpRequestHeader>, method: string, name: string, sortPriority: number, url: string, 
+/**
+ * URL parameters used for both path placeholders (`:id`) and query string entries.
+ */
+urlParameters: Array<HttpUrlParameter>, };
 
 export type HttpRequestHeader = { enabled?: boolean, name: string, value: string, id?: string, };
 
@@ -55,7 +68,12 @@ export type HttpResponseHeader = { name: string, value: string, };
 
 export type HttpResponseState = "initialized" | "connected" | "closed";
 
-export type HttpUrlParameter = { enabled?: boolean, name: string, value: string, id?: string, };
+export type HttpUrlParameter = { enabled?: boolean, 
+/**
+ * Colon-prefixed parameters are treated as path parameters if they match, like `/users/:id`
+ * Other entries are appended as query parameters
+ */
+name: string, value: string, id?: string, };
 
 export type KeyValue = { model: "key_value", id: string, createdAt: string, updatedAt: string, key: string, namespace: string, value: string, };
 
@@ -69,9 +87,9 @@ export type ParentHeaders = { headers: Array<HttpRequestHeader>, };
 
 export type Plugin = { model: "plugin", id: string, createdAt: string, updatedAt: string, checkedAt: string | null, directory: string, enabled: boolean, url: string | null, source: PluginSource, };
 
-export type PluginSource = "bundled" | "filesystem" | "registry";
-
 export type PluginKeyValue = { model: "plugin_key_value", createdAt: string, updatedAt: string, pluginName: string, key: string, value: string, };
+
+export type PluginSource = "bundled" | "filesystem" | "registry";
 
 export type ProxySetting = { "type": "enabled", http: string, https: string, auth: ProxySettingAuth | null, bypass: string, disabled: boolean, } | { "type": "disabled" };
 
@@ -93,8 +111,12 @@ export type WebsocketEventType = "binary" | "close" | "frame" | "open" | "ping" 
 
 export type WebsocketMessageType = "text" | "binary";
 
-export type WebsocketRequest = { model: "websocket_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, description: string, headers: Array<HttpRequestHeader>, message: string, name: string, sortPriority: number, url: string, urlParameters: Array<HttpUrlParameter>, };
+export type WebsocketRequest = { model: "websocket_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, description: string, headers: Array<HttpRequestHeader>, message: string, name: string, sortPriority: number, url: string, 
+/**
+ * URL parameters used for both path placeholders (`:id`) and query string entries.
+ */
+urlParameters: Array<HttpUrlParameter>, };
 
 export type Workspace = { model: "workspace", id: string, createdAt: string, updatedAt: string, authentication: Record<string, any>, authenticationType: string | null, description: string, headers: Array<HttpRequestHeader>, name: string, encryptionKeyChallenge: string | null, settingValidateCertificates: boolean, settingFollowRedirects: boolean, settingRequestTimeout: number, settingDnsOverrides: Array<DnsOverride>, };
 
-export type WorkspaceMeta = { model: "workspace_meta", id: string, workspaceId: string, createdAt: string, updatedAt: string, encryptionKey: EncryptedKey | null, settingSyncDir: string | null, };
+export type WorkspaceMeta = { model: "workspace_meta", id: string, workspaceId: string, createdAt: string, updatedAt: string, encryptionKey: EncryptedKey | null, openapiImportUrl: string | null, openapiLastSyncedAt: string | null, settingSyncDir: string | null, };

--- a/crates/yaak-models/migrations/20260310150000_openapi-import-url.sql
+++ b/crates/yaak-models/migrations/20260310150000_openapi-import-url.sql
@@ -1,0 +1,5 @@
+ALTER TABLE workspace_metas
+    ADD COLUMN openapi_import_url TEXT;
+
+ALTER TABLE workspace_metas
+    ADD COLUMN openapi_last_synced_at DATETIME;

--- a/crates/yaak-models/src/models.rs
+++ b/crates/yaak-models/src/models.rs
@@ -426,6 +426,8 @@ pub struct WorkspaceMeta {
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
     pub encryption_key: Option<EncryptedKey>,
+    pub openapi_import_url: Option<String>,
+    pub openapi_last_synced_at: Option<NaiveDateTime>,
     pub setting_sync_dir: Option<String>,
 }
 
@@ -460,6 +462,8 @@ impl UpsertModelInfo for WorkspaceMeta {
             (UpdatedAt, upsert_date(source, self.updated_at)),
             (WorkspaceId, self.workspace_id.into()),
             (EncryptionKey, self.encryption_key.map(|e| serde_json::to_string(&e).unwrap()).into()),
+            (OpenapiImportUrl, self.openapi_import_url.into()),
+            (OpenapiLastSyncedAt, self.openapi_last_synced_at.into()),
             (SettingSyncDir, self.setting_sync_dir.into()),
         ])
     }
@@ -468,6 +472,8 @@ impl UpsertModelInfo for WorkspaceMeta {
         vec![
             WorkspaceMetaIden::UpdatedAt,
             WorkspaceMetaIden::EncryptionKey,
+            WorkspaceMetaIden::OpenapiImportUrl,
+            WorkspaceMetaIden::OpenapiLastSyncedAt,
             WorkspaceMetaIden::SettingSyncDir,
         ]
     }
@@ -484,6 +490,8 @@ impl UpsertModelInfo for WorkspaceMeta {
             created_at: row.get("created_at")?,
             updated_at: row.get("updated_at")?,
             encryption_key: encryption_key.map(|e| serde_json::from_str(&e).unwrap()),
+            openapi_import_url: row.get("openapi_import_url")?,
+            openapi_last_synced_at: row.get("openapi_last_synced_at")?,
             setting_sync_dir: row.get("setting_sync_dir")?,
         })
     }

--- a/crates/yaak-plugins/bindings/gen_models.ts
+++ b/crates/yaak-plugins/bindings/gen_models.ts
@@ -105,4 +105,4 @@ urlParameters: Array<HttpUrlParameter>, };
 
 export type Workspace = { model: "workspace", id: string, createdAt: string, updatedAt: string, authentication: Record<string, any>, authenticationType: string | null, description: string, headers: Array<HttpRequestHeader>, name: string, encryptionKeyChallenge: string | null, settingValidateCertificates: boolean, settingFollowRedirects: boolean, settingRequestTimeout: number, settingDnsOverrides: Array<DnsOverride>, };
 
-export type WorkspaceMeta = { model: "workspace_meta", id: string, workspaceId: string, createdAt: string, updatedAt: string, encryptionKey: EncryptedKey | null, settingSyncDir: string | null, };
+export type WorkspaceMeta = { model: "workspace_meta", id: string, workspaceId: string, createdAt: string, updatedAt: string, encryptionKey: EncryptedKey | null, openapiImportUrl: string | null, openapiLastSyncedAt: string | null, settingSyncDir: string | null, };

--- a/packages/plugin-runtime-types/src/bindings/gen_models.ts
+++ b/packages/plugin-runtime-types/src/bindings/gen_models.ts
@@ -105,4 +105,4 @@ urlParameters: Array<HttpUrlParameter>, };
 
 export type Workspace = { model: "workspace", id: string, createdAt: string, updatedAt: string, authentication: Record<string, any>, authenticationType: string | null, description: string, headers: Array<HttpRequestHeader>, name: string, encryptionKeyChallenge: string | null, settingValidateCertificates: boolean, settingFollowRedirects: boolean, settingRequestTimeout: number, settingDnsOverrides: Array<DnsOverride>, };
 
-export type WorkspaceMeta = { model: "workspace_meta", id: string, workspaceId: string, createdAt: string, updatedAt: string, encryptionKey: EncryptedKey | null, settingSyncDir: string | null, };
+export type WorkspaceMeta = { model: "workspace_meta", id: string, workspaceId: string, createdAt: string, updatedAt: string, encryptionKey: EncryptedKey | null, openapiImportUrl: string | null, openapiLastSyncedAt: string | null, settingSyncDir: string | null, };

--- a/src-web/components/ImportDataDialog.tsx
+++ b/src-web/components/ImportDataDialog.tsx
@@ -1,16 +1,24 @@
 import { useState } from 'react';
 import { useLocalStorage } from 'react-use';
 import { Button } from './core/Button';
-import { VStack } from './core/Stacks';
+import { PlainInput } from './core/PlainInput';
+import { HStack, VStack } from './core/Stacks';
 import { SelectFile } from './SelectFile';
 
+type ImportSource = 'file' | 'url';
+
 interface Props {
-  importData: (filePath: string) => Promise<void>;
+  importFile: (filePath: string) => Promise<void>;
+  importOpenApiUrl: (url: string) => Promise<void>;
 }
 
-export function ImportDataDialog({ importData }: Props) {
+export function ImportDataDialog({ importFile, importOpenApiUrl }: Props) {
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [source, setSource] = useLocalStorage<ImportSource>('importSource', 'file');
   const [filePath, setFilePath] = useLocalStorage<string | null>('importFilePath', null);
+  const [url, setUrl] = useLocalStorage<string | null>('importOpenApiUrl', null);
+  const activeSource = source ?? 'file';
+  const trimmedUrl = url?.trim() ?? '';
 
   return (
     <VStack space={5} className="pb-4">
@@ -26,27 +34,76 @@ export function ImportDataDialog({ importData }: Props) {
         </ul>
       </VStack>
       <VStack space={2}>
-        <SelectFile
-          filePath={filePath ?? null}
-          onChange={({ filePath }) => setFilePath(filePath)}
-        />
-        {filePath && (
+        <HStack space={2}>
           <Button
-            color="primary"
-            disabled={!filePath || isLoading}
-            isLoading={isLoading}
-            size="sm"
-            onClick={async () => {
-              setIsLoading(true);
-              try {
-                await importData(filePath);
-              } finally {
-                setIsLoading(false);
-              }
-            }}
+            size="xs"
+            variant={activeSource === 'file' ? 'solid' : 'border'}
+            color={activeSource === 'file' ? 'primary' : 'default'}
+            onClick={() => setSource('file')}
           >
-            {isLoading ? 'Importing' : 'Import'}
+            File
           </Button>
+          <Button
+            size="xs"
+            variant={activeSource === 'url' ? 'solid' : 'border'}
+            color={activeSource === 'url' ? 'primary' : 'default'}
+            onClick={() => setSource('url')}
+          >
+            OpenAPI URL
+          </Button>
+        </HStack>
+
+        {activeSource === 'file' ? (
+          <>
+            <SelectFile
+              filePath={filePath ?? null}
+              onChange={({ filePath }) => setFilePath(filePath)}
+            />
+            {filePath && (
+              <Button
+                color="primary"
+                disabled={!filePath || isLoading}
+                isLoading={isLoading}
+                size="sm"
+                onClick={async () => {
+                  setIsLoading(true);
+                  try {
+                    await importFile(filePath);
+                  } finally {
+                    setIsLoading(false);
+                  }
+                }}
+              >
+                {isLoading ? 'Importing' : 'Import'}
+              </Button>
+            )}
+          </>
+        ) : (
+          <>
+            <PlainInput
+              label="OpenAPI URL"
+              hideLabel
+              placeholder="https://example.com/openapi.yaml"
+              defaultValue={url ?? ''}
+              onChange={(value) => setUrl(value)}
+            />
+            <Button
+              color="primary"
+              disabled={trimmedUrl === '' || isLoading}
+              isLoading={isLoading}
+              size="sm"
+              onClick={async () => {
+                setIsLoading(true);
+                try {
+                  await importOpenApiUrl(trimmedUrl);
+                } finally {
+                  setIsLoading(false);
+                }
+              }}
+            >
+              {isLoading ? 'Importing' : 'Import'}
+            </Button>
+          </>
         )}
       </VStack>
     </VStack>

--- a/src-web/components/OpenApiSyncSetting.tsx
+++ b/src-web/components/OpenApiSyncSetting.tsx
@@ -1,0 +1,65 @@
+import { patchModel, type WorkspaceMeta } from '@yaakapp-internal/models';
+import { useState } from 'react';
+import { useStateWithDeps } from '../hooks/useStateWithDeps';
+import { resyncOpenApi } from '../lib/importData';
+import { Button } from './core/Button';
+import { PlainInput } from './core/PlainInput';
+import { VStack } from './core/Stacks';
+
+interface Props {
+  workspaceId: string;
+  workspaceMeta: WorkspaceMeta;
+}
+
+export function OpenApiSyncSetting({ workspaceId, workspaceMeta }: Props) {
+  const [isSyncing, setIsSyncing] = useState(false);
+  const [url, setUrl] = useStateWithDeps(workspaceMeta.openapiImportUrl ?? '', [
+    workspaceMeta.id,
+    workspaceMeta.openapiImportUrl,
+  ]);
+  const trimmedUrl = url.trim();
+  const lastSyncedAt = workspaceMeta.openapiLastSyncedAt
+    ? new Date(workspaceMeta.openapiLastSyncedAt).toLocaleString()
+    : null;
+
+  return (
+    <VStack className="w-full my-2" space={2}>
+      <PlainInput
+        label="OpenAPI URL"
+        size="xs"
+        help="Import and manually resync an OpenAPI document from a remote URL."
+        defaultValue={url}
+        placeholder="https://example.com/openapi.yaml"
+        onChange={(value) => {
+          setUrl(value);
+          patchModel(workspaceMeta, {
+            openapiImportUrl: value.trim() === '' ? null : value.trim(),
+          }).catch(console.error);
+        }}
+      />
+
+      {lastSyncedAt != null && (
+        <div className="text-xs text-text-subtle">Last synced: {lastSyncedAt}</div>
+      )}
+
+      <div>
+        <Button
+          size="xs"
+          color="primary"
+          disabled={trimmedUrl === '' || isSyncing}
+          isLoading={isSyncing}
+          onClick={async () => {
+            setIsSyncing(true);
+            try {
+              await resyncOpenApi.mutateAsync({ url: trimmedUrl, workspaceId });
+            } finally {
+              setIsSyncing(false);
+            }
+          }}
+        >
+          Resync OpenAPI
+        </Button>
+      </div>
+    </VStack>
+  );
+}

--- a/src-web/components/WorkspaceSettingsDialog.tsx
+++ b/src-web/components/WorkspaceSettingsDialog.tsx
@@ -17,6 +17,7 @@ import { DnsOverridesEditor } from './DnsOverridesEditor';
 import { HeadersEditor } from './HeadersEditor';
 import { HttpAuthenticationEditor } from './HttpAuthenticationEditor';
 import { MarkdownEditor } from './MarkdownEditor';
+import { OpenApiSyncSetting } from './OpenApiSyncSetting';
 import { SyncToFilesystemSetting } from './SyncToFilesystemSetting';
 import { WorkspaceEncryptionSetting } from './WorkspaceEncryptionSetting';
 
@@ -156,6 +157,7 @@ export function WorkspaceSettingsDialog({ workspaceId, hide, tab }: Props) {
       </TabContent>
       <TabContent value={TAB_DATA} className="overflow-y-auto h-full px-4">
         <VStack space={4} alignItems="start" className="pb-3 h-full">
+          <OpenApiSyncSetting workspaceId={workspaceId} workspaceMeta={workspaceMeta} />
           <SyncToFilesystemSetting
             value={{ filePath: workspaceMeta.settingSyncDir }}
             onCreateNewWorkspace={hide}

--- a/src-web/lib/importData.tsx
+++ b/src-web/lib/importData.tsx
@@ -3,25 +3,16 @@ import { Button } from '../components/core/Button';
 import { FormattedError } from '../components/core/FormattedError';
 import { VStack } from '../components/core/Stacks';
 import { ImportDataDialog } from '../components/ImportDataDialog';
-import { activeWorkspaceAtom } from '../hooks/useActiveWorkspace';
 import { createFastMutation } from '../hooks/useFastMutation';
 import { showAlert } from './alert';
 import { showDialog } from './dialog';
-import { jotaiStore } from './jotai';
 import { pluralizeCount } from './pluralize';
 import { router } from './router';
 import { invokeCmd } from './tauri';
 
 export const importData = createFastMutation({
   mutationKey: ['import_data'],
-  onError: (err: string) => {
-    showAlert({
-      id: 'import-failed',
-      title: 'Import Failed',
-      size: 'md',
-      body: <FormattedError>{err}</FormattedError>,
-    });
-  },
+  onError: showImportError,
   mutationFn: async () => {
     return new Promise<void>((resolve, reject) => {
       showDialog({
@@ -29,12 +20,9 @@ export const importData = createFastMutation({
         title: 'Import Data',
         size: 'sm',
         render: ({ hide }) => {
-          const importAndHide = async (filePath: string) => {
+          const importAndHide = async (runImport: () => Promise<void>) => {
             try {
-              const didImport = await performImport(filePath);
-              if (!didImport) {
-                return;
-              }
+              await runImport();
               resolve();
             } catch (err) {
               reject(err);
@@ -42,25 +30,61 @@ export const importData = createFastMutation({
               hide();
             }
           };
-          return <ImportDataDialog importData={importAndHide} />;
+
+          return (
+            <ImportDataDialog
+              importFile={(filePath) => importAndHide(() => performFileImport(filePath))}
+              importOpenApiUrl={(url) => importAndHide(() => performOpenApiUrlImport(url))}
+            />
+          );
         },
       });
     });
   },
 });
 
-async function performImport(filePath: string): Promise<boolean> {
-  const activeWorkspace = jotaiStore.get(activeWorkspaceAtom);
-  const imported = await invokeCmd<BatchUpsertResult>('cmd_import_data', {
-    filePath,
-    workspaceId: activeWorkspace?.id,
+export const resyncOpenApi = createFastMutation<
+  BatchUpsertResult,
+  string,
+  { url: string; workspaceId: string }
+>({
+  mutationKey: ['resync_openapi'],
+  onError: showImportError,
+  mutationFn: async ({ url, workspaceId }) => {
+    const imported = await invokeCmd<BatchUpsertResult>('cmd_import_openapi_url', {
+      url,
+      targetWorkspaceId: workspaceId,
+    });
+    showImportComplete(imported, { title: 'OpenAPI Resync Complete' });
+    return imported;
+  },
+});
+
+async function performFileImport(filePath: string): Promise<void> {
+  const imported = await invokeCmd<BatchUpsertResult>('cmd_import_data', { filePath });
+  showImportComplete(imported, { title: 'Import Complete' });
+  await navigateToImportedWorkspace(imported);
+}
+
+async function performOpenApiUrlImport(url: string): Promise<void> {
+  const imported = await invokeCmd<BatchUpsertResult>('cmd_import_openapi_url', { url });
+  showImportComplete(imported, { title: 'Import Complete' });
+  await navigateToImportedWorkspace(imported);
+}
+
+function showImportError(err: unknown) {
+  showAlert({
+    id: 'import-failed',
+    title: 'Import Failed',
+    size: 'md',
+    body: <FormattedError>{String(err)}</FormattedError>,
   });
+}
 
-  const importedWorkspace = imported.workspaces[0];
-
+function showImportComplete(imported: BatchUpsertResult, { title }: { title: string }) {
   showDialog({
     id: 'import-complete',
-    title: 'Import Complete',
+    title,
     size: 'sm',
     hideX: true,
     render: ({ hide }) => {
@@ -95,15 +119,18 @@ async function performImport(filePath: string): Promise<boolean> {
       );
     },
   });
+}
 
-  if (importedWorkspace != null) {
-    const environmentId = imported.environments[0]?.id ?? null;
-    await router.navigate({
-      to: '/workspaces/$workspaceId',
-      params: { workspaceId: importedWorkspace.id },
-      search: { environment_id: environmentId },
-    });
+async function navigateToImportedWorkspace(imported: BatchUpsertResult) {
+  const importedWorkspace = imported.workspaces[0];
+  if (importedWorkspace == null) {
+    return;
   }
 
-  return true;
+  const environmentId = imported.environments[0]?.id ?? null;
+  await router.navigate({
+    to: '/workspaces/$workspaceId',
+    params: { workspaceId: importedWorkspace.id },
+    search: { environment_id: environmentId },
+  });
 }

--- a/src-web/lib/tauri.ts
+++ b/src-web/lib/tauri.ts
@@ -37,6 +37,7 @@ type TauriCmd =
   | 'cmd_http_request_body'
   | 'cmd_http_response_body'
   | 'cmd_import_data'
+  | 'cmd_import_openapi_url'
   | 'cmd_metadata'
   | 'cmd_restart'
   | 'cmd_new_child_window'


### PR DESCRIPTION
## Summary
- add OpenAPI URL import alongside the existing file import flow
- persist the source URL on workspace metadata and expose manual resync in workspace settings
- merge resynced OpenAPI resources into an existing workspace by reusing matched folder and request IDs

Some images below:

<img width="1101" height="600" alt="image" src="https://github.com/user-attachments/assets/8aec0dbe-b7d4-4cba-884a-ecf1a8014462" />
<img width="1105" height="601" alt="image" src="https://github.com/user-attachments/assets/2dab73a2-0cf2-43d6-947f-fc4fab72868d" />


This feature would solve [this](https://yaak.app/feedback/posts/feature-support-openapi-url-synchronization-for-api-import) request