### PR TITLE
Introduce global requests history window

### DIFF
--- a/crates/yaak-git/bindings/gen_models.ts
+++ b/crates/yaak-git/bindings/gen_models.ts
@@ -2,22 +2,44 @@
 
 export type DnsOverride = { hostname: string, ipv4: Array<string>, ipv6: Array<string>, enabled?: boolean, };
 
-export type Environment = { model: "environment", id: string, workspaceId: string, createdAt: string, updatedAt: string, name: string, public: boolean, parentModel: string, parentId: string | null, variables: Array<EnvironmentVariable>, color: string | null, sortPriority: number, };
+export type Environment = { model: "environment", id: string, workspaceId: string, createdAt: string, updatedAt: string, name: string, public: boolean, parentModel: string, parentId: string | null, 
+/**
+ * Variables defined in this environment scope.
+ * Child environments override parent variables by name.
+ */
+variables: Array<EnvironmentVariable>, color: string | null, sortPriority: number, };
 
 export type EnvironmentVariable = { enabled?: boolean, name: string, value: string, id?: string, };
 
 export type Folder = { model: "folder", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, description: string, headers: Array<HttpRequestHeader>, name: string, sortPriority: number, };
 
-export type GrpcRequest = { model: "grpc_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authenticationType: string | null, authentication: Record<string, any>, description: string, message: string, metadata: Array<HttpRequestHeader>, method: string | null, name: string, service: string | null, sortPriority: number, url: string, };
+export type GrpcRequest = { model: "grpc_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authenticationType: string | null, authentication: Record<string, any>, description: string, message: string, metadata: Array<HttpRequestHeader>, method: string | null, name: string, service: string | null, sortPriority: number, 
+/**
+ * Server URL (http for plaintext or https for secure)
+ */
+url: string, };
 
-export type HttpRequest = { model: "http_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, body: Record<string, any>, bodyType: string | null, description: string, headers: Array<HttpRequestHeader>, method: string, name: string, sortPriority: number, url: string, urlParameters: Array<HttpUrlParameter>, };
+export type HttpRequest = { model: "http_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, body: Record<string, any>, bodyType: string | null, description: string, headers: Array<HttpRequestHeader>, method: string, name: string, sortPriority: number, url: string, 
+/**
+ * URL parameters used for both path placeholders (`:id`) and query string entries.
+ */
+urlParameters: Array<HttpUrlParameter>, };
 
 export type HttpRequestHeader = { enabled?: boolean, name: string, value: string, id?: string, };
 
-export type HttpUrlParameter = { enabled?: boolean, name: string, value: string, id?: string, };
+export type HttpUrlParameter = { enabled?: boolean, 
+/**
+ * Colon-prefixed parameters are treated as path parameters if they match, like `/users/:id`
+ * Other entries are appended as query parameters
+ */
+name: string, value: string, id?: string, };
 
 export type SyncModel = { "type": "workspace" } & Workspace | { "type": "environment" } & Environment | { "type": "folder" } & Folder | { "type": "http_request" } & HttpRequest | { "type": "grpc_request" } & GrpcRequest | { "type": "websocket_request" } & WebsocketRequest;
 
-export type WebsocketRequest = { model: "websocket_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, description: string, headers: Array<HttpRequestHeader>, message: string, name: string, sortPriority: number, url: string, urlParameters: Array<HttpUrlParameter>, };
+export type WebsocketRequest = { model: "websocket_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, description: string, headers: Array<HttpRequestHeader>, message: string, name: string, sortPriority: number, url: string, 
+/**
+ * URL parameters used for both path placeholders (`:id`) and query string entries.
+ */
+urlParameters: Array<HttpUrlParameter>, };
 
 export type Workspace = { model: "workspace", id: string, createdAt: string, updatedAt: string, authentication: Record<string, any>, authenticationType: string | null, description: string, headers: Array<HttpRequestHeader>, name: string, encryptionKeyChallenge: string | null, settingValidateCertificates: boolean, settingFollowRedirects: boolean, settingRequestTimeout: number, settingDnsOverrides: Array<DnsOverride>, };

--- a/crates/yaak-models/bindings/gen_models.ts
+++ b/crates/yaak-models/bindings/gen_models.ts
@@ -18,7 +18,12 @@ export type EditorKeymap = "default" | "vim" | "vscode" | "emacs";
 
 export type EncryptedKey = { encryptedKey: string, };
 
-export type Environment = { model: "environment", id: string, workspaceId: string, createdAt: string, updatedAt: string, name: string, public: boolean, parentModel: string, parentId: string | null, variables: Array<EnvironmentVariable>, color: string | null, sortPriority: number, };
+export type Environment = { model: "environment", id: string, workspaceId: string, createdAt: string, updatedAt: string, name: string, public: boolean, parentModel: string, parentId: string | null, 
+/**
+ * Variables defined in this environment scope.
+ * Child environments override parent variables by name.
+ */
+variables: Array<EnvironmentVariable>, color: string | null, sortPriority: number, };
 
 export type EnvironmentVariable = { enabled?: boolean, name: string, value: string, id?: string, };
 
@@ -34,13 +39,21 @@ export type GrpcEvent = { model: "grpc_event", id: string, createdAt: string, up
 
 export type GrpcEventType = "info" | "error" | "client_message" | "server_message" | "connection_start" | "connection_end";
 
-export type GrpcRequest = { model: "grpc_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authenticationType: string | null, authentication: Record<string, any>, description: string, message: string, metadata: Array<HttpRequestHeader>, method: string | null, name: string, service: string | null, sortPriority: number, url: string, };
+export type GrpcRequest = { model: "grpc_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authenticationType: string | null, authentication: Record<string, any>, description: string, message: string, metadata: Array<HttpRequestHeader>, method: string | null, name: string, service: string | null, sortPriority: number, 
+/**
+ * Server URL (http for plaintext or https for secure)
+ */
+url: string, };
 
-export type HttpRequest = { model: "http_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, body: Record<string, any>, bodyType: string | null, description: string, headers: Array<HttpRequestHeader>, method: string, name: string, sortPriority: number, url: string, urlParameters: Array<HttpUrlParameter>, };
+export type HttpRequest = { model: "http_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, body: Record<string, any>, bodyType: string | null, description: string, headers: Array<HttpRequestHeader>, method: string, name: string, sortPriority: number, url: string, 
+/**
+ * URL parameters used for both path placeholders (`:id`) and query string entries.
+ */
+urlParameters: Array<HttpUrlParameter>, };
 
 export type HttpRequestHeader = { enabled?: boolean, name: string, value: string, id?: string, };
 
-export type HttpResponse = { model: "http_response", id: string, createdAt: string, updatedAt: string, workspaceId: string, requestId: string, bodyPath: string | null, contentLength: number | null, contentLengthCompressed: number | null, elapsed: number, elapsedHeaders: number, elapsedDns: number, error: string | null, headers: Array<HttpResponseHeader>, remoteAddr: string | null, requestContentLength: number | null, requestHeaders: Array<HttpResponseHeader>, status: number, statusReason: string | null, state: HttpResponseState, url: string, version: string | null, };
+export type HttpResponse = { model: "http_response", id: string, createdAt: string, updatedAt: string, workspaceId: string, requestId: string, bodyPath: string | null, contentLength: number | null, contentLengthCompressed: number | null, elapsed: number, elapsedHeaders: number, elapsedDns: number, error: string | null, headers: Array<HttpResponseHeader>, remoteAddr: string | null, requestContentLength: number | null, requestHeaders: Array<HttpResponseHeader>, method: string | null, requestName: string | null, requestBodyType: string | null, status: number, statusReason: string | null, state: HttpResponseState, url: string, version: string | null, };
 
 export type HttpResponseEvent = { model: "http_response_event", id: string, createdAt: string, updatedAt: string, workspaceId: string, responseId: string, event: HttpResponseEventData, };
 
@@ -55,7 +68,12 @@ export type HttpResponseHeader = { name: string, value: string, };
 
 export type HttpResponseState = "initialized" | "connected" | "closed";
 
-export type HttpUrlParameter = { enabled?: boolean, name: string, value: string, id?: string, };
+export type HttpUrlParameter = { enabled?: boolean, 
+/**
+ * Colon-prefixed parameters are treated as path parameters if they match, like `/users/:id`
+ * Other entries are appended as query parameters
+ */
+name: string, value: string, id?: string, };
 
 export type KeyValue = { model: "key_value", id: string, createdAt: string, updatedAt: string, key: string, namespace: string, value: string, };
 
@@ -69,9 +87,9 @@ export type ParentHeaders = { headers: Array<HttpRequestHeader>, };
 
 export type Plugin = { model: "plugin", id: string, createdAt: string, updatedAt: string, checkedAt: string | null, directory: string, enabled: boolean, url: string | null, source: PluginSource, };
 
-export type PluginSource = "bundled" | "filesystem" | "registry";
-
 export type PluginKeyValue = { model: "plugin_key_value", createdAt: string, updatedAt: string, pluginName: string, key: string, value: string, };
+
+export type PluginSource = "bundled" | "filesystem" | "registry";
 
 export type ProxySetting = { "type": "enabled", http: string, https: string, auth: ProxySettingAuth | null, bypass: string, disabled: boolean, } | { "type": "disabled" };
 
@@ -93,7 +111,11 @@ export type WebsocketEventType = "binary" | "close" | "frame" | "open" | "ping" 
 
 export type WebsocketMessageType = "text" | "binary";
 
-export type WebsocketRequest = { model: "websocket_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, description: string, headers: Array<HttpRequestHeader>, message: string, name: string, sortPriority: number, url: string, urlParameters: Array<HttpUrlParameter>, };
+export type WebsocketRequest = { model: "websocket_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, description: string, headers: Array<HttpRequestHeader>, message: string, name: string, sortPriority: number, url: string, 
+/**
+ * URL parameters used for both path placeholders (`:id`) and query string entries.
+ */
+urlParameters: Array<HttpUrlParameter>, };
 
 export type Workspace = { model: "workspace", id: string, createdAt: string, updatedAt: string, authentication: Record<string, any>, authenticationType: string | null, description: string, headers: Array<HttpRequestHeader>, name: string, encryptionKeyChallenge: string | null, settingValidateCertificates: boolean, settingFollowRedirects: boolean, settingRequestTimeout: number, settingDnsOverrides: Array<DnsOverride>, };
 

--- a/crates/yaak-models/migrations/20260418000000_http-response-method-and-request-name.sql
+++ b/crates/yaak-models/migrations/20260418000000_http-response-method-and-request-name.sql
@@ -1,0 +1,34 @@
+-- Freeze the HTTP method, the originating request's name, and the request
+-- body type on each response so history rows don't drift when the request is
+-- later edited.
+ALTER TABLE http_responses ADD COLUMN method TEXT;
+ALTER TABLE http_responses ADD COLUMN request_name TEXT;
+ALTER TABLE http_responses ADD COLUMN request_body_type TEXT;
+
+-- Backfill method from the matching `send_url` event when we have one.
+UPDATE http_responses
+SET method = (
+    SELECT json_extract(e.event, '$.method')
+    FROM http_response_events e
+    WHERE e.response_id = http_responses.id
+      AND json_extract(e.event, '$.type') = 'send_url'
+    ORDER BY e.created_at ASC
+    LIMIT 1
+);
+
+-- Fall back to the current request method for older responses without events.
+UPDATE http_responses
+SET method = (
+    SELECT method FROM http_requests WHERE id = http_responses.request_id
+)
+WHERE method IS NULL;
+
+UPDATE http_responses
+SET request_name = (
+    SELECT name FROM http_requests WHERE id = http_responses.request_id
+);
+
+UPDATE http_responses
+SET request_body_type = (
+    SELECT body_type FROM http_requests WHERE id = http_responses.request_id
+);

--- a/crates/yaak-models/src/models.rs
+++ b/crates/yaak-models/src/models.rs
@@ -1366,6 +1366,9 @@ pub struct HttpResponse {
     pub remote_addr: Option<String>,
     pub request_content_length: Option<i32>,
     pub request_headers: Vec<HttpResponseHeader>,
+    pub method: Option<String>,
+    pub request_name: Option<String>,
+    pub request_body_type: Option<String>,
     pub status: i32,
     pub status_reason: Option<String>,
     pub state: HttpResponseState,
@@ -1414,6 +1417,9 @@ impl UpsertModelInfo for HttpResponse {
             (Headers, serde_json::to_string(&self.headers)?.into()),
             (RemoteAddr, self.remote_addr.into()),
             (RequestHeaders, serde_json::to_string(&self.request_headers)?.into()),
+            (Method, self.method.into()),
+            (RequestName, self.request_name.into()),
+            (RequestBodyType, self.request_body_type.into()),
             (State, serde_json::to_value(self.state)?.as_str().into()),
             (Status, self.status.into()),
             (StatusReason, self.status_reason.into()),
@@ -1437,6 +1443,9 @@ impl UpsertModelInfo for HttpResponse {
             HttpResponseIden::RemoteAddr,
             HttpResponseIden::RequestContentLength,
             HttpResponseIden::RequestHeaders,
+            HttpResponseIden::Method,
+            HttpResponseIden::RequestName,
+            HttpResponseIden::RequestBodyType,
             HttpResponseIden::State,
             HttpResponseIden::Status,
             HttpResponseIden::StatusReason,
@@ -1477,6 +1486,9 @@ impl UpsertModelInfo for HttpResponse {
                 r.get::<_, String>("request_headers").unwrap_or_default().as_str(),
             )
             .unwrap_or_default(),
+            method: r.get("method").unwrap_or_default(),
+            request_name: r.get("request_name").unwrap_or_default(),
+            request_body_type: r.get("request_body_type").unwrap_or_default(),
         })
     }
 }

--- a/crates/yaak-plugins/bindings/gen_events.ts
+++ b/crates/yaak-plugins/bindings/gen_events.ts
@@ -18,12 +18,12 @@ export type CallHttpAuthenticationActionRequest = { index: number, pluginRefId: 
 
 export type CallHttpAuthenticationRequest = { contextId: string, values: { [key in string]?: JsonPrimitive }, method: string, url: string, headers: Array<HttpHeader>, };
 
-export type CallHttpAuthenticationResponse = {
+export type CallHttpAuthenticationResponse = { 
 /**
  * HTTP headers to add to the request. Existing headers will be replaced, while
  * new headers will be added.
  */
-setHeaders?: Array<HttpHeader>,
+setHeaders?: Array<HttpHeader>, 
 /**
  * Query parameters to add to the request. Existing params will be replaced, while
  * new params will be added.
@@ -78,7 +78,7 @@ export type ExportHttpRequestRequest = { httpRequest: HttpRequest, };
 
 export type ExportHttpRequestResponse = { content: string, };
 
-export type FileFilter = { name: string,
+export type FileFilter = { name: string, 
 /**
  * File extensions to require
  */
@@ -100,149 +100,149 @@ export type FormInputAccordion = { label: string, inputs?: Array<FormInput>, hid
 
 export type FormInputBanner = { inputs?: Array<FormInput>, hidden?: boolean, color?: Color, };
 
-export type FormInputBase = {
+export type FormInputBase = { 
 /**
  * The name of the input. The value will be stored at this object attribute in the resulting data
  */
-name: string,
+name: string, 
 /**
  * Whether this input is visible for the given configuration. Use this to
  * make branching forms.
  */
-hidden?: boolean,
+hidden?: boolean, 
 /**
  * Whether the user must fill in the argument
  */
-optional?: boolean,
+optional?: boolean, 
 /**
  * The label of the input
  */
-label?: string,
+label?: string, 
 /**
  * Visually hide the label of the input
  */
-hideLabel?: boolean,
+hideLabel?: boolean, 
 /**
  * The default value
  */
-defaultValue?: string, disabled?: boolean,
+defaultValue?: string, disabled?: boolean, 
 /**
  * Longer description of the input, likely shown in a tooltip
  */
 description?: string, };
 
-export type FormInputCheckbox = {
+export type FormInputCheckbox = { 
 /**
  * The name of the input. The value will be stored at this object attribute in the resulting data
  */
-name: string,
+name: string, 
 /**
  * Whether this input is visible for the given configuration. Use this to
  * make branching forms.
  */
-hidden?: boolean,
+hidden?: boolean, 
 /**
  * Whether the user must fill in the argument
  */
-optional?: boolean,
+optional?: boolean, 
 /**
  * The label of the input
  */
-label?: string,
+label?: string, 
 /**
  * Visually hide the label of the input
  */
-hideLabel?: boolean,
+hideLabel?: boolean, 
 /**
  * The default value
  */
-defaultValue?: string, disabled?: boolean,
+defaultValue?: string, disabled?: boolean, 
 /**
  * Longer description of the input, likely shown in a tooltip
  */
 description?: string, };
 
-export type FormInputEditor = {
+export type FormInputEditor = { 
 /**
  * Placeholder for the text input
  */
-placeholder?: string | null,
+placeholder?: string | null, 
 /**
  * Don't show the editor gutter (line numbers, folds, etc.)
  */
-hideGutter?: boolean,
+hideGutter?: boolean, 
 /**
  * Language for syntax highlighting
  */
-language?: EditorLanguage, readOnly?: boolean,
+language?: EditorLanguage, readOnly?: boolean, 
 /**
  * Fixed number of visible rows
  */
-rows?: number, completionOptions?: Array<GenericCompletionOption>,
+rows?: number, completionOptions?: Array<GenericCompletionOption>, 
 /**
  * The name of the input. The value will be stored at this object attribute in the resulting data
  */
-name: string,
+name: string, 
 /**
  * Whether this input is visible for the given configuration. Use this to
  * make branching forms.
  */
-hidden?: boolean,
+hidden?: boolean, 
 /**
  * Whether the user must fill in the argument
  */
-optional?: boolean,
+optional?: boolean, 
 /**
  * The label of the input
  */
-label?: string,
+label?: string, 
 /**
  * Visually hide the label of the input
  */
-hideLabel?: boolean,
+hideLabel?: boolean, 
 /**
  * The default value
  */
-defaultValue?: string, disabled?: boolean,
+defaultValue?: string, disabled?: boolean, 
 /**
  * Longer description of the input, likely shown in a tooltip
  */
 description?: string, };
 
-export type FormInputFile = {
+export type FormInputFile = { 
 /**
  * The title of the file selection window
  */
-title: string,
+title: string, 
 /**
  * Allow selecting multiple files
  */
-multiple?: boolean, directory?: boolean, defaultPath?: string, filters?: Array<FileFilter>,
+multiple?: boolean, directory?: boolean, defaultPath?: string, filters?: Array<FileFilter>, 
 /**
  * The name of the input. The value will be stored at this object attribute in the resulting data
  */
-name: string,
+name: string, 
 /**
  * Whether this input is visible for the given configuration. Use this to
  * make branching forms.
  */
-hidden?: boolean,
+hidden?: boolean, 
 /**
  * Whether the user must fill in the argument
  */
-optional?: boolean,
+optional?: boolean, 
 /**
  * The label of the input
  */
-label?: string,
+label?: string, 
 /**
  * Visually hide the label of the input
  */
-hideLabel?: boolean,
+hideLabel?: boolean, 
 /**
  * The default value
  */
-defaultValue?: string, disabled?: boolean,
+defaultValue?: string, disabled?: boolean, 
 /**
  * Longer description of the input, likely shown in a tooltip
  */
@@ -250,63 +250,63 @@ description?: string, };
 
 export type FormInputHStack = { inputs?: Array<FormInput>, hidden?: boolean, };
 
-export type FormInputHttpRequest = {
+export type FormInputHttpRequest = { 
 /**
  * The name of the input. The value will be stored at this object attribute in the resulting data
  */
-name: string,
+name: string, 
 /**
  * Whether this input is visible for the given configuration. Use this to
  * make branching forms.
  */
-hidden?: boolean,
+hidden?: boolean, 
 /**
  * Whether the user must fill in the argument
  */
-optional?: boolean,
+optional?: boolean, 
 /**
  * The label of the input
  */
-label?: string,
+label?: string, 
 /**
  * Visually hide the label of the input
  */
-hideLabel?: boolean,
+hideLabel?: boolean, 
 /**
  * The default value
  */
-defaultValue?: string, disabled?: boolean,
+defaultValue?: string, disabled?: boolean, 
 /**
  * Longer description of the input, likely shown in a tooltip
  */
 description?: string, };
 
-export type FormInputKeyValue = {
+export type FormInputKeyValue = { 
 /**
  * The name of the input. The value will be stored at this object attribute in the resulting data
  */
-name: string,
+name: string, 
 /**
  * Whether this input is visible for the given configuration. Use this to
  * make branching forms.
  */
-hidden?: boolean,
+hidden?: boolean, 
 /**
  * Whether the user must fill in the argument
  */
-optional?: boolean,
+optional?: boolean, 
 /**
  * The label of the input
  */
-label?: string,
+label?: string, 
 /**
  * Visually hide the label of the input
  */
-hideLabel?: boolean,
+hideLabel?: boolean, 
 /**
  * The default value
  */
-defaultValue?: string, disabled?: boolean,
+defaultValue?: string, disabled?: boolean, 
 /**
  * Longer description of the input, likely shown in a tooltip
  */
@@ -314,36 +314,36 @@ description?: string, };
 
 export type FormInputMarkdown = { content: string, hidden?: boolean, };
 
-export type FormInputSelect = {
+export type FormInputSelect = { 
 /**
  * The options that will be available in the select input
  */
-options: Array<FormInputSelectOption>,
+options: Array<FormInputSelectOption>, 
 /**
  * The name of the input. The value will be stored at this object attribute in the resulting data
  */
-name: string,
+name: string, 
 /**
  * Whether this input is visible for the given configuration. Use this to
  * make branching forms.
  */
-hidden?: boolean,
+hidden?: boolean, 
 /**
  * Whether the user must fill in the argument
  */
-optional?: boolean,
+optional?: boolean, 
 /**
  * The label of the input
  */
-label?: string,
+label?: string, 
 /**
  * Visually hide the label of the input
  */
-hideLabel?: boolean,
+hideLabel?: boolean, 
 /**
  * The default value
  */
-defaultValue?: string, disabled?: boolean,
+defaultValue?: string, disabled?: boolean, 
 /**
  * Longer description of the input, likely shown in a tooltip
  */
@@ -351,44 +351,44 @@ description?: string, };
 
 export type FormInputSelectOption = { label: string, value: string, };
 
-export type FormInputText = {
+export type FormInputText = { 
 /**
  * Placeholder for the text input
  */
-placeholder?: string | null,
+placeholder?: string | null, 
 /**
  * Placeholder for the text input
  */
-password?: boolean,
+password?: boolean, 
 /**
  * Whether to allow newlines in the input, like a <textarea/>
  */
-multiLine?: boolean, completionOptions?: Array<GenericCompletionOption>,
+multiLine?: boolean, completionOptions?: Array<GenericCompletionOption>, 
 /**
  * The name of the input. The value will be stored at this object attribute in the resulting data
  */
-name: string,
+name: string, 
 /**
  * Whether this input is visible for the given configuration. Use this to
  * make branching forms.
  */
-hidden?: boolean,
+hidden?: boolean, 
 /**
  * Whether the user must fill in the argument
  */
-optional?: boolean,
+optional?: boolean, 
 /**
  * The label of the input
  */
-label?: string,
+label?: string, 
 /**
  * Visually hide the label of the input
  */
-hideLabel?: boolean,
+hideLabel?: boolean, 
 /**
  * The default value
  */
-defaultValue?: string, disabled?: boolean,
+defaultValue?: string, disabled?: boolean, 
 /**
  * Longer description of the input, likely shown in a tooltip
  */
@@ -474,7 +474,7 @@ export type ListOpenWorkspacesResponse = { workspaces: Array<WorkspaceInfo>, };
 
 export type OpenExternalUrlRequest = { url: string, };
 
-export type OpenWindowRequest = { url: string,
+export type OpenWindowRequest = { url: string, 
 /**
  * Label for the window. If not provided, a random one will be generated.
  */
@@ -486,15 +486,15 @@ export type PromptFormRequest = { id: string, title: string, description?: strin
 
 export type PromptFormResponse = { values: { [key in string]?: JsonPrimitive } | null, done?: boolean, };
 
-export type PromptTextRequest = { id: string, title: string, label: string, description?: string, defaultValue?: string, placeholder?: string,
+export type PromptTextRequest = { id: string, title: string, label: string, description?: string, defaultValue?: string, placeholder?: string, 
 /**
  * Text to add to the confirmation button
  */
-confirmText?: string, password?: boolean,
+confirmText?: string, password?: boolean, 
 /**
  * Text to add to the cancel button
  */
-cancelText?: string,
+cancelText?: string, 
 /**
  * Require the user to enter a non-empty value
  */
@@ -524,12 +524,12 @@ export type SetKeyValueResponse = {};
 
 export type ShowToastRequest = { message: string, color?: Color, icon?: Icon, timeout?: number, };
 
-export type TemplateFunction = { name: string, previewType?: TemplateFunctionPreviewType, description?: string,
+export type TemplateFunction = { name: string, previewType?: TemplateFunctionPreviewType, description?: string, 
 /**
  * Also support alternative names. This is useful for not breaking existing
  * tags when changing the `name` property
  */
-aliases?: Array<string>, args: Array<TemplateFunctionArg>,
+aliases?: Array<string>, args: Array<TemplateFunctionArg>, 
 /**
  * A list of arg names to show in the inline preview. If not provided, none will be shown (for privacy reasons).
  */
@@ -546,23 +546,23 @@ export type TemplateRenderRequest = { data: JsonValue, purpose: RenderPurpose, }
 
 export type TemplateRenderResponse = { data: JsonValue, };
 
-export type Theme = {
+export type Theme = { 
 /**
  * How the theme is identified. This should never be changed
  */
-id: string,
+id: string, 
 /**
  * The friendly name of the theme to be displayed to the user
  */
-label: string,
+label: string, 
 /**
  * Whether the theme will be used for dark or light appearance
  */
-dark: boolean,
+dark: boolean, 
 /**
  * The default top-level colors for the theme
  */
-base: ThemeComponentColors,
+base: ThemeComponentColors, 
 /**
  * Optionally override theme for individual UI components for more control
  */

--- a/crates/yaak-plugins/bindings/gen_models.ts
+++ b/crates/yaak-plugins/bindings/gen_models.ts
@@ -53,7 +53,7 @@ urlParameters: Array<HttpUrlParameter>, };
 
 export type HttpRequestHeader = { enabled?: boolean, name: string, value: string, id?: string, };
 
-export type HttpResponse = { model: "http_response", id: string, createdAt: string, updatedAt: string, workspaceId: string, requestId: string, bodyPath: string | null, contentLength: number | null, contentLengthCompressed: number | null, elapsed: number, elapsedHeaders: number, elapsedDns: number, error: string | null, headers: Array<HttpResponseHeader>, remoteAddr: string | null, requestContentLength: number | null, requestHeaders: Array<HttpResponseHeader>, status: number, statusReason: string | null, state: HttpResponseState, url: string, version: string | null, };
+export type HttpResponse = { model: "http_response", id: string, createdAt: string, updatedAt: string, workspaceId: string, requestId: string, bodyPath: string | null, contentLength: number | null, contentLengthCompressed: number | null, elapsed: number, elapsedHeaders: number, elapsedDns: number, error: string | null, headers: Array<HttpResponseHeader>, remoteAddr: string | null, requestContentLength: number | null, requestHeaders: Array<HttpResponseHeader>, method: string | null, requestName: string | null, requestBodyType: string | null, status: number, statusReason: string | null, state: HttpResponseState, url: string, version: string | null, };
 
 export type HttpResponseEvent = { model: "http_response_event", id: string, createdAt: string, updatedAt: string, workspaceId: string, responseId: string, event: HttpResponseEventData, };
 

--- a/crates/yaak-sync/bindings/gen_models.ts
+++ b/crates/yaak-sync/bindings/gen_models.ts
@@ -2,24 +2,46 @@
 
 export type DnsOverride = { hostname: string, ipv4: Array<string>, ipv6: Array<string>, enabled?: boolean, };
 
-export type Environment = { model: "environment", id: string, workspaceId: string, createdAt: string, updatedAt: string, name: string, public: boolean, parentModel: string, parentId: string | null, variables: Array<EnvironmentVariable>, color: string | null, sortPriority: number, };
+export type Environment = { model: "environment", id: string, workspaceId: string, createdAt: string, updatedAt: string, name: string, public: boolean, parentModel: string, parentId: string | null, 
+/**
+ * Variables defined in this environment scope.
+ * Child environments override parent variables by name.
+ */
+variables: Array<EnvironmentVariable>, color: string | null, sortPriority: number, };
 
 export type EnvironmentVariable = { enabled?: boolean, name: string, value: string, id?: string, };
 
 export type Folder = { model: "folder", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, description: string, headers: Array<HttpRequestHeader>, name: string, sortPriority: number, };
 
-export type GrpcRequest = { model: "grpc_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authenticationType: string | null, authentication: Record<string, any>, description: string, message: string, metadata: Array<HttpRequestHeader>, method: string | null, name: string, service: string | null, sortPriority: number, url: string, };
+export type GrpcRequest = { model: "grpc_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authenticationType: string | null, authentication: Record<string, any>, description: string, message: string, metadata: Array<HttpRequestHeader>, method: string | null, name: string, service: string | null, sortPriority: number, 
+/**
+ * Server URL (http for plaintext or https for secure)
+ */
+url: string, };
 
-export type HttpRequest = { model: "http_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, body: Record<string, any>, bodyType: string | null, description: string, headers: Array<HttpRequestHeader>, method: string, name: string, sortPriority: number, url: string, urlParameters: Array<HttpUrlParameter>, };
+export type HttpRequest = { model: "http_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, body: Record<string, any>, bodyType: string | null, description: string, headers: Array<HttpRequestHeader>, method: string, name: string, sortPriority: number, url: string, 
+/**
+ * URL parameters used for both path placeholders (`:id`) and query string entries.
+ */
+urlParameters: Array<HttpUrlParameter>, };
 
 export type HttpRequestHeader = { enabled?: boolean, name: string, value: string, id?: string, };
 
-export type HttpUrlParameter = { enabled?: boolean, name: string, value: string, id?: string, };
+export type HttpUrlParameter = { enabled?: boolean, 
+/**
+ * Colon-prefixed parameters are treated as path parameters if they match, like `/users/:id`
+ * Other entries are appended as query parameters
+ */
+name: string, value: string, id?: string, };
 
 export type SyncModel = { "type": "workspace" } & Workspace | { "type": "environment" } & Environment | { "type": "folder" } & Folder | { "type": "http_request" } & HttpRequest | { "type": "grpc_request" } & GrpcRequest | { "type": "websocket_request" } & WebsocketRequest;
 
 export type SyncState = { model: "sync_state", id: string, workspaceId: string, createdAt: string, updatedAt: string, flushedAt: string, modelId: string, checksum: string, relPath: string, syncDir: string, };
 
-export type WebsocketRequest = { model: "websocket_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, description: string, headers: Array<HttpRequestHeader>, message: string, name: string, sortPriority: number, url: string, urlParameters: Array<HttpUrlParameter>, };
+export type WebsocketRequest = { model: "websocket_request", id: string, createdAt: string, updatedAt: string, workspaceId: string, folderId: string | null, authentication: Record<string, any>, authenticationType: string | null, description: string, headers: Array<HttpRequestHeader>, message: string, name: string, sortPriority: number, url: string, 
+/**
+ * URL parameters used for both path placeholders (`:id`) and query string entries.
+ */
+urlParameters: Array<HttpUrlParameter>, };
 
 export type Workspace = { model: "workspace", id: string, createdAt: string, updatedAt: string, authentication: Record<string, any>, authenticationType: string | null, description: string, headers: Array<HttpRequestHeader>, name: string, encryptionKeyChallenge: string | null, settingValidateCertificates: boolean, settingFollowRedirects: boolean, settingRequestTimeout: number, settingDnsOverrides: Array<DnsOverride>, };

--- a/crates/yaak/src/send.rs
+++ b/crates/yaak/src/send.rs
@@ -491,6 +491,9 @@ pub async fn send_http_request<T: TemplateCallback>(
         .iter()
         .map(|(name, value)| HttpResponseHeader { name: name.clone(), value: value.clone() })
         .collect();
+    response.method = Some(sendable_request.method.clone());
+    response.request_name = Some(params.request.name.clone());
+    response.request_body_type = params.request.body_type.clone();
     response.url = sendable_request.url.clone();
     response.state = HttpResponseState::Initialized;
     response.error = None;

--- a/packages/plugin-runtime-types/src/bindings/gen_events.ts
+++ b/packages/plugin-runtime-types/src/bindings/gen_events.ts
@@ -18,12 +18,12 @@ export type CallHttpAuthenticationActionRequest = { index: number, pluginRefId: 
 
 export type CallHttpAuthenticationRequest = { contextId: string, values: { [key in string]?: JsonPrimitive }, method: string, url: string, headers: Array<HttpHeader>, };
 
-export type CallHttpAuthenticationResponse = {
+export type CallHttpAuthenticationResponse = { 
 /**
  * HTTP headers to add to the request. Existing headers will be replaced, while
  * new headers will be added.
  */
-setHeaders?: Array<HttpHeader>,
+setHeaders?: Array<HttpHeader>, 
 /**
  * Query parameters to add to the request. Existing params will be replaced, while
  * new params will be added.
@@ -78,7 +78,7 @@ export type ExportHttpRequestRequest = { httpRequest: HttpRequest, };
 
 export type ExportHttpRequestResponse = { content: string, };
 
-export type FileFilter = { name: string,
+export type FileFilter = { name: string, 
 /**
  * File extensions to require
  */
@@ -100,149 +100,149 @@ export type FormInputAccordion = { label: string, inputs?: Array<FormInput>, hid
 
 export type FormInputBanner = { inputs?: Array<FormInput>, hidden?: boolean, color?: Color, };
 
-export type FormInputBase = {
+export type FormInputBase = { 
 /**
  * The name of the input. The value will be stored at this object attribute in the resulting data
  */
-name: string,
+name: string, 
 /**
  * Whether this input is visible for the given configuration. Use this to
  * make branching forms.
  */
-hidden?: boolean,
+hidden?: boolean, 
 /**
  * Whether the user must fill in the argument
  */
-optional?: boolean,
+optional?: boolean, 
 /**
  * The label of the input
  */
-label?: string,
+label?: string, 
 /**
  * Visually hide the label of the input
  */
-hideLabel?: boolean,
+hideLabel?: boolean, 
 /**
  * The default value
  */
-defaultValue?: string, disabled?: boolean,
+defaultValue?: string, disabled?: boolean, 
 /**
  * Longer description of the input, likely shown in a tooltip
  */
 description?: string, };
 
-export type FormInputCheckbox = {
+export type FormInputCheckbox = { 
 /**
  * The name of the input. The value will be stored at this object attribute in the resulting data
  */
-name: string,
+name: string, 
 /**
  * Whether this input is visible for the given configuration. Use this to
  * make branching forms.
  */
-hidden?: boolean,
+hidden?: boolean, 
 /**
  * Whether the user must fill in the argument
  */
-optional?: boolean,
+optional?: boolean, 
 /**
  * The label of the input
  */
-label?: string,
+label?: string, 
 /**
  * Visually hide the label of the input
  */
-hideLabel?: boolean,
+hideLabel?: boolean, 
 /**
  * The default value
  */
-defaultValue?: string, disabled?: boolean,
+defaultValue?: string, disabled?: boolean, 
 /**
  * Longer description of the input, likely shown in a tooltip
  */
 description?: string, };
 
-export type FormInputEditor = {
+export type FormInputEditor = { 
 /**
  * Placeholder for the text input
  */
-placeholder?: string | null,
+placeholder?: string | null, 
 /**
  * Don't show the editor gutter (line numbers, folds, etc.)
  */
-hideGutter?: boolean,
+hideGutter?: boolean, 
 /**
  * Language for syntax highlighting
  */
-language?: EditorLanguage, readOnly?: boolean,
+language?: EditorLanguage, readOnly?: boolean, 
 /**
  * Fixed number of visible rows
  */
-rows?: number, completionOptions?: Array<GenericCompletionOption>,
+rows?: number, completionOptions?: Array<GenericCompletionOption>, 
 /**
  * The name of the input. The value will be stored at this object attribute in the resulting data
  */
-name: string,
+name: string, 
 /**
  * Whether this input is visible for the given configuration. Use this to
  * make branching forms.
  */
-hidden?: boolean,
+hidden?: boolean, 
 /**
  * Whether the user must fill in the argument
  */
-optional?: boolean,
+optional?: boolean, 
 /**
  * The label of the input
  */
-label?: string,
+label?: string, 
 /**
  * Visually hide the label of the input
  */
-hideLabel?: boolean,
+hideLabel?: boolean, 
 /**
  * The default value
  */
-defaultValue?: string, disabled?: boolean,
+defaultValue?: string, disabled?: boolean, 
 /**
  * Longer description of the input, likely shown in a tooltip
  */
 description?: string, };
 
-export type FormInputFile = {
+export type FormInputFile = { 
 /**
  * The title of the file selection window
  */
-title: string,
+title: string, 
 /**
  * Allow selecting multiple files
  */
-multiple?: boolean, directory?: boolean, defaultPath?: string, filters?: Array<FileFilter>,
+multiple?: boolean, directory?: boolean, defaultPath?: string, filters?: Array<FileFilter>, 
 /**
  * The name of the input. The value will be stored at this object attribute in the resulting data
  */
-name: string,
+name: string, 
 /**
  * Whether this input is visible for the given configuration. Use this to
  * make branching forms.
  */
-hidden?: boolean,
+hidden?: boolean, 
 /**
  * Whether the user must fill in the argument
  */
-optional?: boolean,
+optional?: boolean, 
 /**
  * The label of the input
  */
-label?: string,
+label?: string, 
 /**
  * Visually hide the label of the input
  */
-hideLabel?: boolean,
+hideLabel?: boolean, 
 /**
  * The default value
  */
-defaultValue?: string, disabled?: boolean,
+defaultValue?: string, disabled?: boolean, 
 /**
  * Longer description of the input, likely shown in a tooltip
  */
@@ -250,63 +250,63 @@ description?: string, };
 
 export type FormInputHStack = { inputs?: Array<FormInput>, hidden?: boolean, };
 
-export type FormInputHttpRequest = {
+export type FormInputHttpRequest = { 
 /**
  * The name of the input. The value will be stored at this object attribute in the resulting data
  */
-name: string,
+name: string, 
 /**
  * Whether this input is visible for the given configuration. Use this to
  * make branching forms.
  */
-hidden?: boolean,
+hidden?: boolean, 
 /**
  * Whether the user must fill in the argument
  */
-optional?: boolean,
+optional?: boolean, 
 /**
  * The label of the input
  */
-label?: string,
+label?: string, 
 /**
  * Visually hide the label of the input
  */
-hideLabel?: boolean,
+hideLabel?: boolean, 
 /**
  * The default value
  */
-defaultValue?: string, disabled?: boolean,
+defaultValue?: string, disabled?: boolean, 
 /**
  * Longer description of the input, likely shown in a tooltip
  */
 description?: string, };
 
-export type FormInputKeyValue = {
+export type FormInputKeyValue = { 
 /**
  * The name of the input. The value will be stored at this object attribute in the resulting data
  */
-name: string,
+name: string, 
 /**
  * Whether this input is visible for the given configuration. Use this to
  * make branching forms.
  */
-hidden?: boolean,
+hidden?: boolean, 
 /**
  * Whether the user must fill in the argument
  */
-optional?: boolean,
+optional?: boolean, 
 /**
  * The label of the input
  */
-label?: string,
+label?: string, 
 /**
  * Visually hide the label of the input
  */
-hideLabel?: boolean,
+hideLabel?: boolean, 
 /**
  * The default value
  */
-defaultValue?: string, disabled?: boolean,
+defaultValue?: string, disabled?: boolean, 
 /**
  * Longer description of the input, likely shown in a tooltip
  */
@@ -314,36 +314,36 @@ description?: string, };
 
 export type FormInputMarkdown = { content: string, hidden?: boolean, };
 
-export type FormInputSelect = {
+export type FormInputSelect = { 
 /**
  * The options that will be available in the select input
  */
-options: Array<FormInputSelectOption>,
+options: Array<FormInputSelectOption>, 
 /**
  * The name of the input. The value will be stored at this object attribute in the resulting data
  */
-name: string,
+name: string, 
 /**
  * Whether this input is visible for the given configuration. Use this to
  * make branching forms.
  */
-hidden?: boolean,
+hidden?: boolean, 
 /**
  * Whether the user must fill in the argument
  */
-optional?: boolean,
+optional?: boolean, 
 /**
  * The label of the input
  */
-label?: string,
+label?: string, 
 /**
  * Visually hide the label of the input
  */
-hideLabel?: boolean,
+hideLabel?: boolean, 
 /**
  * The default value
  */
-defaultValue?: string, disabled?: boolean,
+defaultValue?: string, disabled?: boolean, 
 /**
  * Longer description of the input, likely shown in a tooltip
  */
@@ -351,44 +351,44 @@ description?: string, };
 
 export type FormInputSelectOption = { label: string, value: string, };
 
-export type FormInputText = {
+export type FormInputText = { 
 /**
  * Placeholder for the text input
  */
-placeholder?: string | null,
+placeholder?: string | null, 
 /**
  * Placeholder for the text input
  */
-password?: boolean,
+password?: boolean, 
 /**
  * Whether to allow newlines in the input, like a <textarea/>
  */
-multiLine?: boolean, completionOptions?: Array<GenericCompletionOption>,
+multiLine?: boolean, completionOptions?: Array<GenericCompletionOption>, 
 /**
  * The name of the input. The value will be stored at this object attribute in the resulting data
  */
-name: string,
+name: string, 
 /**
  * Whether this input is visible for the given configuration. Use this to
  * make branching forms.
  */
-hidden?: boolean,
+hidden?: boolean, 
 /**
  * Whether the user must fill in the argument
  */
-optional?: boolean,
+optional?: boolean, 
 /**
  * The label of the input
  */
-label?: string,
+label?: string, 
 /**
  * Visually hide the label of the input
  */
-hideLabel?: boolean,
+hideLabel?: boolean, 
 /**
  * The default value
  */
-defaultValue?: string, disabled?: boolean,
+defaultValue?: string, disabled?: boolean, 
 /**
  * Longer description of the input, likely shown in a tooltip
  */
@@ -474,7 +474,7 @@ export type ListOpenWorkspacesResponse = { workspaces: Array<WorkspaceInfo>, };
 
 export type OpenExternalUrlRequest = { url: string, };
 
-export type OpenWindowRequest = { url: string,
+export type OpenWindowRequest = { url: string, 
 /**
  * Label for the window. If not provided, a random one will be generated.
  */
@@ -486,15 +486,15 @@ export type PromptFormRequest = { id: string, title: string, description?: strin
 
 export type PromptFormResponse = { values: { [key in string]?: JsonPrimitive } | null, done?: boolean, };
 
-export type PromptTextRequest = { id: string, title: string, label: string, description?: string, defaultValue?: string, placeholder?: string,
+export type PromptTextRequest = { id: string, title: string, label: string, description?: string, defaultValue?: string, placeholder?: string, 
 /**
  * Text to add to the confirmation button
  */
-confirmText?: string, password?: boolean,
+confirmText?: string, password?: boolean, 
 /**
  * Text to add to the cancel button
  */
-cancelText?: string,
+cancelText?: string, 
 /**
  * Require the user to enter a non-empty value
  */
@@ -524,12 +524,12 @@ export type SetKeyValueResponse = {};
 
 export type ShowToastRequest = { message: string, color?: Color, icon?: Icon, timeout?: number, };
 
-export type TemplateFunction = { name: string, previewType?: TemplateFunctionPreviewType, description?: string,
+export type TemplateFunction = { name: string, previewType?: TemplateFunctionPreviewType, description?: string, 
 /**
  * Also support alternative names. This is useful for not breaking existing
  * tags when changing the `name` property
  */
-aliases?: Array<string>, args: Array<TemplateFunctionArg>,
+aliases?: Array<string>, args: Array<TemplateFunctionArg>, 
 /**
  * A list of arg names to show in the inline preview. If not provided, none will be shown (for privacy reasons).
  */
@@ -546,23 +546,23 @@ export type TemplateRenderRequest = { data: JsonValue, purpose: RenderPurpose, }
 
 export type TemplateRenderResponse = { data: JsonValue, };
 
-export type Theme = {
+export type Theme = { 
 /**
  * How the theme is identified. This should never be changed
  */
-id: string,
+id: string, 
 /**
  * The friendly name of the theme to be displayed to the user
  */
-label: string,
+label: string, 
 /**
  * Whether the theme will be used for dark or light appearance
  */
-dark: boolean,
+dark: boolean, 
 /**
  * The default top-level colors for the theme
  */
-base: ThemeComponentColors,
+base: ThemeComponentColors, 
 /**
  * Optionally override theme for individual UI components for more control
  */

--- a/packages/plugin-runtime-types/src/bindings/gen_models.ts
+++ b/packages/plugin-runtime-types/src/bindings/gen_models.ts
@@ -53,7 +53,7 @@ urlParameters: Array<HttpUrlParameter>, };
 
 export type HttpRequestHeader = { enabled?: boolean, name: string, value: string, id?: string, };
 
-export type HttpResponse = { model: "http_response", id: string, createdAt: string, updatedAt: string, workspaceId: string, requestId: string, bodyPath: string | null, contentLength: number | null, contentLengthCompressed: number | null, elapsed: number, elapsedHeaders: number, elapsedDns: number, error: string | null, headers: Array<HttpResponseHeader>, remoteAddr: string | null, requestContentLength: number | null, requestHeaders: Array<HttpResponseHeader>, status: number, statusReason: string | null, state: HttpResponseState, url: string, version: string | null, };
+export type HttpResponse = { model: "http_response", id: string, createdAt: string, updatedAt: string, workspaceId: string, requestId: string, bodyPath: string | null, contentLength: number | null, contentLengthCompressed: number | null, elapsed: number, elapsedHeaders: number, elapsedDns: number, error: string | null, headers: Array<HttpResponseHeader>, remoteAddr: string | null, requestContentLength: number | null, requestHeaders: Array<HttpResponseHeader>, method: string | null, requestName: string | null, requestBodyType: string | null, status: number, statusReason: string | null, state: HttpResponseState, url: string, version: string | null, };
 
 export type HttpResponseEvent = { model: "http_response_event", id: string, createdAt: string, updatedAt: string, workspaceId: string, responseId: string, event: HttpResponseEventData, };
 

--- a/src-web/commands/openHistory.ts
+++ b/src-web/commands/openHistory.ts
@@ -1,0 +1,20 @@
+import { activeWorkspaceIdAtom } from "../hooks/useActiveWorkspace";
+import { createFastMutation } from "../hooks/useFastMutation";
+import { jotaiStore } from "../lib/jotai";
+import { router } from "../lib/router";
+import { invokeCmd } from "../lib/tauri";
+
+export const openHistory = createFastMutation<void, string, void>({
+  mutationKey: ["open_history"],
+  mutationFn: async () => {
+    const workspaceId = jotaiStore.get(activeWorkspaceIdAtom);
+    if (workspaceId == null) return;
+
+    const location = router.buildLocation({
+      to: "/workspaces/$workspaceId/history",
+      params: { workspaceId },
+    });
+
+    await invokeCmd("cmd_new_main_window", { url: location.href });
+  },
+});

--- a/src-web/components/CommandPaletteDialog.tsx
+++ b/src-web/components/CommandPaletteDialog.tsx
@@ -45,6 +45,7 @@ import {
 } from "../lib/resolvedModelName";
 import { router } from "../lib/router";
 import { setWorkspaceSearchParams } from "../lib/setWorkspaceSearchParams";
+import { openHistory } from "../commands/openHistory";
 import { CookieDialog } from "./CookieDialog";
 import { Button } from "./core/Button";
 import { Heading } from "./core/Heading";
@@ -137,6 +138,11 @@ export function CommandPaletteDialog({ onClose }: { onClose: () => void }) {
             render: () => <CookieDialog cookieJarId={activeCookieJar?.id ?? null} />,
           });
         },
+      },
+      {
+        key: "history.show",
+        label: "Show Request History",
+        onSelect: () => openHistory.mutate(),
       },
       {
         key: "environment.edit",

--- a/src-web/components/HttpHistoryPage.tsx
+++ b/src-web/components/HttpHistoryPage.tsx
@@ -1,0 +1,546 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { HttpResponse, HttpResponseEvent } from "@yaakapp-internal/models";
+import { deleteModel, httpResponsesAtom } from "@yaakapp-internal/models";
+import classNames from "classnames";
+import { useAtomValue } from "jotai";
+import type { ComponentType, ReactNode } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { activeWorkspaceIdAtom } from "../hooks/useActiveWorkspace";
+import { allRequestsAtom } from "../hooks/useAllRequests";
+import { useDeleteSendHistory } from "../hooks/useDeleteSendHistory";
+import { useResponseBodyBytes, useResponseBodyText } from "../hooks/useResponseBodyText";
+import { getMimeTypeFromContentType } from "../lib/contentType";
+import { getContentTypeFromHeaders } from "../lib/model_util";
+import { Button } from "./core/Button";
+import { CountBadge } from "./core/CountBadge";
+import { IconButton } from "./core/IconButton";
+import { HttpMethodTagRaw } from "./core/HttpMethodTag";
+import { HttpResponseDurationTag } from "./core/HttpResponseDurationTag";
+import { HttpStatusTag } from "./core/HttpStatusTag";
+import { KeyValueRow, KeyValueRows } from "./core/KeyValueRow";
+import { LoadingIcon } from "./core/LoadingIcon";
+import { HStack } from "./core/Stacks";
+import { EmptyStateText } from "./EmptyStateText";
+import { ErrorBoundary } from "./ErrorBoundary";
+import { HeaderSize } from "./HeaderSize";
+import { HttpResponseTimeline } from "./HttpResponseTimeline";
+import { RequestBodyViewer } from "./RequestBodyViewer";
+import { AudioViewer } from "./responseViewers/AudioViewer";
+import { CsvViewer } from "./responseViewers/CsvViewer";
+import { EventStreamViewer } from "./responseViewers/EventStreamViewer";
+import { HTMLOrTextViewer } from "./responseViewers/HTMLOrTextViewer";
+import { ImageViewer } from "./responseViewers/ImageViewer";
+import { MultipartViewer } from "./responseViewers/MultipartViewer";
+import { SvgViewer } from "./responseViewers/SvgViewer";
+import { VideoViewer } from "./responseViewers/VideoViewer";
+
+const PdfViewer = lazy(() =>
+  import("./responseViewers/PdfViewer").then((m) => ({ default: m.PdfViewer })),
+);
+
+const PAGE_SIZE = 50;
+
+interface HistoryEntry {
+  response: HttpResponse;
+  requestName: string;
+  requestMethod: string;
+}
+
+export function HttpHistoryPage() {
+  const allResponses = useAtomValue(httpResponsesAtom);
+  const allRequests = useAtomValue(allRequestsAtom);
+  const activeWorkspaceId = useAtomValue(activeWorkspaceIdAtom);
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const deleteSendHistory = useDeleteSendHistory();
+
+  useEffect(() => {
+    setExpandedIds(new Set());
+    setVisibleCount(PAGE_SIZE);
+  }, [activeWorkspaceId]);
+
+  const entries = useMemo<HistoryEntry[]>(() => {
+    const requestsById = new Map(allRequests.map((r) => [r.id, r]));
+    const out: HistoryEntry[] = [];
+    for (const response of allResponses) {
+      if (response.workspaceId !== activeWorkspaceId) continue;
+      const request = requestsById.get(response.requestId) ?? null;
+      const isGraphql = response.requestBodyType === "graphql";
+      out.push({
+        response,
+        requestName:
+          response.requestName ?? (request == null ? "(deleted request)" : ""),
+        requestMethod: isGraphql ? "graphql" : (response.method ?? "unknown"),
+      });
+    }
+    return out;
+  }, [allResponses, allRequests, activeWorkspaceId]);
+
+  const toggleExpanded = useCallback(
+    (id: string) =>
+      setExpandedIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      }),
+    [],
+  );
+
+  const handleDelete = useCallback((response: HttpResponse) => {
+    setExpandedIds((prev) => {
+      if (!prev.has(response.id)) return prev;
+      const next = new Set(prev);
+      next.delete(response.id);
+      return next;
+    });
+    void deleteModel(response);
+  }, []);
+
+  return (
+    <div className="h-full w-full flex flex-col bg-surface text-text">
+      <HeaderSize size="lg">
+        <div className="flex items-center gap-3 px-3 h-full">
+          <h1 className="text-sm font-semibold">History</h1>
+          <span className="text-xs text-text-subtle">{entries.length} requests</span>
+          {expandedIds.size > 0 && (
+            <Button size="2xs" variant="border" onClick={() => setExpandedIds(new Set())}>
+              Collapse All
+            </Button>
+          )}
+          <div className="flex-1" />
+          {entries.length > 0 && (
+            <Button
+              size="2xs"
+              variant="border"
+              onClick={async () => {
+                const deleted = await deleteSendHistory.mutateAsync();
+                if (deleted) setExpandedIds(new Set());
+              }}
+            >
+              Clear All
+            </Button>
+          )}
+        </div>
+      </HeaderSize>
+
+      <div className="flex-1 overflow-y-auto">
+        {entries.length === 0 ? (
+          <EmptyStateText>No request history yet</EmptyStateText>
+        ) : (
+          <>
+            <table className="w-full text-sm">
+              <thead className="sticky top-0 bg-surface z-10">
+                <tr className="text-left text-text-subtle text-xs uppercase">
+                  <th className="pl-4 pr-1 py-2 font-medium w-[1.5rem]" />
+                  <th className="px-4 py-2 font-medium w-[5rem]">Status</th>
+                  <th className="px-4 py-2 font-medium w-[4rem]">Method</th>
+                  <th className="px-4 py-2 font-medium">Request</th>
+                  <th className="px-4 py-2 font-medium w-[6rem] text-right">Time</th>
+                  <th className="px-4 py-2 font-medium w-[14rem] text-right">Timestamp</th>
+                  <th className="w-[2rem]" />
+                </tr>
+              </thead>
+              <tbody>
+                {entries.slice(0, visibleCount).map((entry) => (
+                  <HistoryRow
+                    key={entry.response.id}
+                    entry={entry}
+                    isExpanded={expandedIds.has(entry.response.id)}
+                    onToggle={toggleExpanded}
+                    onDelete={handleDelete}
+                  />
+                ))}
+              </tbody>
+            </table>
+            {visibleCount < entries.length && (
+              <div className="flex justify-center py-3">
+                <Button
+                  size="xs"
+                  variant="border"
+                  onClick={() => setVisibleCount((n) => n + PAGE_SIZE)}
+                >
+                  Load More ({entries.length - visibleCount} remaining)
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function HistoryRow({
+  entry,
+  isExpanded,
+  onToggle,
+  onDelete,
+}: {
+  entry: HistoryEntry;
+  isExpanded: boolean;
+  onToggle: (id: string) => void;
+  onDelete: (response: HttpResponse) => void;
+}) {
+  const { response, requestName, requestMethod } = entry;
+
+  return (
+    <>
+      <tr
+        className={classNames("cursor-pointer transition-colors group hover:bg-surface-highlight")}
+        onClick={() => onToggle(response.id)}
+      >
+        <td className="pl-4 pr-1 py-2">
+          <div
+            className={classNames(
+              "transition-transform w-0 h-0",
+              "border-t-[0.3em] border-b-[0.3em] border-l-[0.5em] border-r-0",
+              "border-t-transparent border-b-transparent border-l-text-subtle",
+              isExpanded && "rotate-90",
+            )}
+          />
+        </td>
+        <td className="px-4 py-2">
+          <HttpStatusTag response={response} short />
+        </td>
+        <td className="px-4 py-2">
+          <HttpMethodTagRaw method={requestMethod} className="text-xs" forceColor />
+        </td>
+        <td className="px-4 py-2">
+          <div className="truncate font-mono" title={response.url}>
+            {response.url}
+          </div>
+          {requestName && (
+            <div className="truncate text-text-subtlest text-xs" title={requestName}>
+              {requestName}
+            </div>
+          )}
+        </td>
+        <td className="px-4 py-2 text-right text-text-subtle">
+          <HttpResponseDurationTag response={response} />
+        </td>
+        <td className="px-4 py-2 text-right text-text-subtle font-mono text-xs tabular-nums">
+          {formatTimestamp(response.createdAt)}
+        </td>
+        <td className="pr-4 py-2 w-[2rem]">
+          <IconButton
+            iconSize="sm"
+            icon="trash"
+            title="Delete response"
+            className="!bg-transparent !shadow-none opacity-50 hover:!opacity-100"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(response);
+            }}
+          />
+        </td>
+      </tr>
+      {isExpanded && (
+        <tr className="">
+          <td colSpan={7}>
+            <HistoryDetail response={response} />
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function HistoryDetail({ response }: { response: HttpResponse }) {
+  const [activeTab, setActiveTab] = useState<string>("body");
+  const contentType = getContentTypeFromHeaders(response.headers);
+  const mimeType = contentType == null ? null : getMimeTypeFromContentType(contentType).essence;
+  const [localEvents, setLocalEvents] = useState<HttpResponseEvent[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    void invoke<HttpResponseEvent[]>("cmd_get_http_response_events", {
+      responseId: response.id,
+    }).then((events) => {
+      if (!cancelled) setLocalEvents(events);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [response.id]);
+  const queryParams = useMemo(() => {
+    try {
+      return Array.from(new URL(response.url).searchParams.entries());
+    } catch {
+      return [];
+    }
+  }, [response.url]);
+
+  const requestHeaders = useMemo(
+    () =>
+      [...response.requestHeaders].sort((a, b) =>
+        a.name.toLocaleLowerCase().localeCompare(b.name.toLocaleLowerCase()),
+      ),
+    [response.requestHeaders],
+  );
+  const responseHeaders = useMemo(
+    () =>
+      [...response.headers].sort((a, b) =>
+        a.name.toLocaleLowerCase().localeCompare(b.name.toLocaleLowerCase()),
+      ),
+    [response.headers],
+  );
+
+  const tabs = [
+    { key: "body", label: "Body" },
+    {
+      key: "headers",
+      label: "Headers",
+      badge: `${requestHeaders.length} / ${responseHeaders.length}`,
+    },
+    { key: "timeline", label: "Timeline", badge: localEvents.length },
+  ];
+
+  return (
+    <div className="px-4 py-3">
+      <HStack space={1} className="mb-2">
+        {tabs.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => setActiveTab(t.key)}
+            className={classNames(
+              "px-2 py-1 rounded text-xs font-medium transition-colors",
+              activeTab === t.key ? "text-text" : "text-text-subtle hover:text-text",
+            )}
+          >
+            {t.label}
+            {t.badge != null && t.badge !== 0 && (
+              <span className="ml-1.5 opacity-70">{t.badge}</span>
+            )}
+          </button>
+        ))}
+      </HStack>
+
+      {activeTab === "body" && (
+        <div className="flex gap-3 items-start">
+          <div className="flex-1 min-w-0">
+            {queryParams.length > 0 && (
+              <div className="rounded border border-dashed border-border-subtle bg-surface p-2 mb-2">
+                <h4 className="text-xs font-medium text-text-subtle uppercase mb-1">
+                  Query Parameters
+                </h4>
+                <table className="w-full text-xs">
+                  <tbody>
+                    {queryParams.map(([key, value], i) => (
+                      // oxlint-disable-next-line react/no-array-index-key
+                      <tr key={`${key}-${i}`}>
+                        <td className="pr-3 py-0.5 font-mono text-primary whitespace-nowrap">
+                          {key}
+                        </td>
+                        <td className="py-0.5 font-mono break-all">{value}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            <RequestBodyPane response={response} />
+          </div>
+          <div className="flex-1 min-w-0 rounded border border-dashed border-border-subtle bg-surface [&_.cm-editor]:!border-0 [&_.border-dashed]:!border-0">
+            <h3 className="text-xs font-medium text-text-subtle uppercase p-2 pb-0">
+              Response Body
+            </h3>
+            <div className="h-[10rem] min-h-[4rem] max-h-[60rem] resize-y overflow-auto p-2 pt-1">
+              <ResponseBodySection response={response} mimeType={mimeType} />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {activeTab === "headers" && (
+        <div className="flex gap-3 items-start">
+          <div className="flex-1 min-w-0 max-h-[30rem] overflow-auto flex flex-col gap-2">
+            <div className="rounded border border-dashed border-border-subtle bg-surface p-2">
+              <h3 className="text-xs font-medium text-text-subtle uppercase mb-1">Info</h3>
+              <KeyValueRows>
+                <KeyValueRow labelColor="secondary" label="Request URL">
+                  <span className="select-text cursor-text break-all">{response.url}</span>
+                </KeyValueRow>
+                <KeyValueRow labelColor="secondary" label="Remote Address">
+                  {response.remoteAddr ?? <span className="text-text-subtlest">--</span>}
+                </KeyValueRow>
+                <KeyValueRow labelColor="secondary" label="Version">
+                  {response.version ?? <span className="text-text-subtlest">--</span>}
+                </KeyValueRow>
+              </KeyValueRows>
+            </div>
+            <div className="rounded border border-dashed border-border-subtle bg-surface p-2">
+              <h3 className="text-xs font-medium text-text-subtle uppercase mb-1 flex items-center">
+                Request Headers
+                <CountBadge showZero count={requestHeaders.length} />
+              </h3>
+              {requestHeaders.length === 0 ? (
+                <span className="text-text-subtlest text-sm italic">No Headers</span>
+              ) : (
+                <KeyValueRows>
+                  {requestHeaders.map((h, i) => (
+                    // oxlint-disable-next-line react/no-array-index-key
+                    <KeyValueRow labelColor="primary" key={i} label={h.name}>
+                      {h.value}
+                    </KeyValueRow>
+                  ))}
+                </KeyValueRows>
+              )}
+            </div>
+          </div>
+          <div className="flex-1 min-w-0 max-h-[30rem] overflow-auto">
+            <div className="rounded border border-dashed border-border-subtle bg-surface p-2">
+              <h3 className="text-xs font-medium text-text-subtle uppercase mb-1 flex items-center">
+                Response Headers
+                <CountBadge showZero count={responseHeaders.length} />
+              </h3>
+              {responseHeaders.length === 0 ? (
+                <span className="text-text-subtlest text-sm italic">No Headers</span>
+              ) : (
+                <KeyValueRows>
+                  {responseHeaders.map((h, i) => (
+                    // oxlint-disable-next-line react/no-array-index-key
+                    <KeyValueRow labelColor="info" key={i} label={h.name}>
+                      {h.value}
+                    </KeyValueRow>
+                  ))}
+                </KeyValueRows>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {activeTab === "timeline" && (
+        <div className="max-h-[30rem] overflow-auto rounded border border-dashed border-border-subtle bg-surface p-2">
+          <HttpResponseTimeline response={response} viewMode="timeline" events={localEvents} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ResponseBodySection({
+  response,
+  mimeType,
+}: {
+  response: HttpResponse;
+  mimeType: string | null;
+}) {
+  if (response.state === "initialized") {
+    return (
+      <BodyEmpty>
+        <HStack space={3}>
+          <LoadingIcon className="text-text-subtlest" />
+          Sending Request
+        </HStack>
+      </BodyEmpty>
+    );
+  }
+
+  if (response.error) {
+    return <BodyEmpty>{response.error}</BodyEmpty>;
+  }
+
+  if (response.state === "closed" && ((response.contentLength ?? 0) === 0 || !response.bodyPath)) {
+    return <BodyEmpty>No response body</BodyEmpty>;
+  }
+
+  return (
+    <ErrorBoundary name="History Response Viewer">
+      <Suspense>
+        {mimeType?.match(/^text\/event-stream/i) ? (
+          <EventStreamViewer response={response} />
+        ) : mimeType?.match(/^image\/svg/) ? (
+          <HistorySvgViewer response={response} />
+        ) : mimeType?.match(/^image/i) ? (
+          <EnsureComplete response={response} Component={ImageViewer} />
+        ) : mimeType?.match(/^audio/i) ? (
+          <EnsureComplete response={response} Component={AudioViewer} />
+        ) : mimeType?.match(/^video/i) ? (
+          <EnsureComplete response={response} Component={VideoViewer} />
+        ) : mimeType?.match(/^multipart/i) ? (
+          <HistoryMultipartViewer response={response} />
+        ) : mimeType?.match(/pdf/i) ? (
+          <EnsureComplete response={response} Component={PdfViewer} />
+        ) : mimeType?.match(/csv|tab-separated/i) ? (
+          <HistoryCsvViewer response={response} />
+        ) : (
+          <HTMLOrTextViewer response={response} pretty textViewerClassName="bg-surface" />
+        )}
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+
+function EnsureComplete({
+  response,
+  Component,
+}: {
+  response: HttpResponse;
+  Component: ComponentType<{ bodyPath: string }>;
+}) {
+  if (response.bodyPath === null) return <BodyEmpty>No response body</BodyEmpty>;
+  if (response.state !== "closed") {
+    return (
+      <BodyEmpty>
+        <LoadingIcon />
+      </BodyEmpty>
+    );
+  }
+  return <Component bodyPath={response.bodyPath} />;
+}
+
+function HistorySvgViewer({ response }: { response: HttpResponse }) {
+  const body = useResponseBodyText({ response, filter: null });
+  if (!body.data) return null;
+  return <SvgViewer text={body.data} />;
+}
+
+function HistoryCsvViewer({ response }: { response: HttpResponse }) {
+  const body = useResponseBodyText({ response, filter: null });
+  return <CsvViewer text={body.data ?? null} />;
+}
+
+function HistoryMultipartViewer({ response }: { response: HttpResponse }) {
+  const body = useResponseBodyBytes({ response });
+  if (body.data == null) return null;
+  const contentTypeHeader = getContentTypeFromHeaders(response.headers);
+  const boundary = contentTypeHeader?.split("boundary=")[1] ?? "unknown";
+  return <MultipartViewer data={body.data} boundary={boundary} idPrefix={response.id} />;
+}
+
+function RequestBodyPane({ response }: { response: HttpResponse }) {
+  const hasBody = (response.requestContentLength ?? 0) > 0;
+  return (
+    <div className="rounded border border-dashed border-border-subtle bg-surface [&_.cm-editor]:!border-0 [&_.border-dashed]:!border-0">
+      <h3 className="text-xs font-medium text-text-subtle uppercase p-2 pb-0">Request Body</h3>
+      {hasBody ? (
+        <div className="h-[10rem] min-h-[4rem] max-h-[60rem] resize-y overflow-auto p-2 pt-1">
+          <RequestBodyViewer response={response} />
+        </div>
+      ) : (
+        <div className="p-2 pt-1">
+          <BodyEmpty>No request body</BodyEmpty>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BodyEmpty({ children }: { children: ReactNode }) {
+  return (
+    <div className="h-full flex items-center justify-center py-6 text-text-subtlest italic text-sm">
+      {children}
+    </div>
+  );
+}
+
+function formatTimestamp(createdAt: string): string {
+  const d = new Date(`${createdAt}Z`);
+  const pad = (n: number, len = 2) => String(n).padStart(len, "0");
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+    `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`
+  );
+}

--- a/src-web/components/HttpResponseTimeline.tsx
+++ b/src-web/components/HttpResponseTimeline.tsx
@@ -16,15 +16,30 @@ import type { TimelineViewMode } from "./HttpResponsePane";
 interface Props {
   response: HttpResponse;
   viewMode: TimelineViewMode;
+  events?: HttpResponseEvent[];
 }
 
-export function HttpResponseTimeline({ response, viewMode }: Props) {
-  return <Inner key={response.id} response={response} viewMode={viewMode} />;
+export function HttpResponseTimeline({ response, viewMode, events: externalEvents }: Props) {
+  return (
+    <Inner
+      key={response.id}
+      response={response}
+      viewMode={viewMode}
+      externalEvents={externalEvents}
+    />
+  );
 }
 
-function Inner({ response, viewMode }: Props) {
+function Inner({
+  response,
+  viewMode,
+  externalEvents,
+}: Props & { externalEvents?: HttpResponseEvent[] }) {
   const [showRaw, setShowRaw] = useState(false);
-  const { data: events, error, isLoading } = useHttpResponseEvents(response);
+  const fetched = useHttpResponseEvents(externalEvents != null ? null : response);
+  const events = externalEvents ?? fetched.data;
+  const error = externalEvents != null ? null : fetched.error;
+  const isLoading = externalEvents != null ? false : fetched.isLoading;
 
   // Generate plain text representation of all events (with prefixes for timeline view)
   const plainText = useMemo(() => {

--- a/src-web/components/RequestBodyViewer.tsx
+++ b/src-web/components/RequestBodyViewer.tsx
@@ -1,8 +1,11 @@
 import type { HttpResponse } from "@yaakapp-internal/models";
 import { lazy, Suspense } from "react";
 import { useHttpRequestBody } from "../hooks/useHttpRequestBody";
+import { tryFormatGraphql } from "../lib/formatters";
 import { getMimeTypeFromContentType, languageFromContentType } from "../lib/contentType";
+import { Editor } from "./core/Editor/LazyEditor";
 import { LoadingIcon } from "./core/LoadingIcon";
+import { Separator } from "./core/Separator";
 import { EmptyStateText } from "./EmptyStateText";
 import { AudioViewer } from "./responseViewers/AudioViewer";
 import { CsvViewer } from "./responseViewers/CsvViewer";
@@ -45,6 +48,10 @@ function RequestBodyViewerInner({ response }: Props) {
   }
 
   const { bodyText, body } = data;
+
+  if (response.requestBodyType === "graphql") {
+    return <GraphQLRequestBodyViewer response={response} bodyText={bodyText} />;
+  }
 
   // Try to detect language from content-type header that was sent
   const contentTypeHeader = response.requestHeaders.find(
@@ -99,4 +106,50 @@ function RequestBodyViewerInner({ response }: Props) {
   return (
     <TextViewer text={bodyText} language={language} stateKey={`request.body.${response.id}`} />
   );
+}
+
+function GraphQLRequestBodyViewer({
+  response,
+  bodyText,
+}: {
+  response: HttpResponse;
+  bodyText: string;
+}) {
+  const body = tryParseJson(bodyText, {});
+  const query = typeof body.query === "string" ? body.query : bodyText;
+  const variables =
+    body.variables == null ? null : JSON.stringify(body.variables, null, 2) ?? null;
+
+  return (
+    <div className="h-full w-full grid grid-cols-1 grid-rows-[minmax(0,100%)_auto]">
+      <Editor
+        readOnly
+        defaultValue={query}
+        language="graphql"
+        format={tryFormatGraphql}
+        stateKey={`request.body.graphql.${response.id}`}
+      />
+      {variables != null ? (
+        <div className="grid grid-rows-[auto_minmax(0,1fr)] grid-cols-1 min-h-[5rem]">
+          <Separator dashed className="pb-1">
+            Variables
+          </Separator>
+          <TextViewer
+            text={variables}
+            language="json"
+            pretty
+            stateKey={`request.body.graphql.variables.${response.id}`}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function tryParseJson(text: string, fallback: Record<string, unknown>) {
+  try {
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return fallback;
+  }
 }

--- a/src-web/routes/workspaces/$workspaceId/history.tsx
+++ b/src-web/routes/workspaces/$workspaceId/history.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { HttpHistoryPage } from "../../../components/HttpHistoryPage";
+
+export const Route = createFileRoute("/workspaces/$workspaceId/history")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return <HttpHistoryPage />;
+}


### PR DESCRIPTION
## Summary

This is getting close but **it's still a work in progress**.

I'm adding a global history window to see all previous requests, with their body, method and so on. It's mostly frontend work but there is some database schema change needed. I believe this should live together with the existing history per request, not replace it.

* **Small DB change**
Because of the way history works now, some attributes are not saved and rely on the current request. Like `method`, `name` and `body_type`. I have added those to the response table.

* **UI and features**
I went for a separate window because I like it more. It's accessible via the `cmd + K` palette.
I added a button to collapse all requests, to delete all requests, to delete one request. I'm missing one button to replay/restore a request specifically.

* **HTTP + Graphql**
For now, only http and graphql requests are supported. gRPC and websocket could be handled in a future release. Ideally, I'd add filters at the very top and you can see only one type at the time. They are in different tables so it's annoying to handle pagination and such. And I think you only really need to see one at a time.

Any feedback is very welcome!

## Submission

- [x] This PR is a bug fix or small-scope improvement.
- [x] If this PR is not a bug fix or small-scope improvement, I linked an approved feedback item below.
- [x] I have read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
- [x] I tested this change locally.
- [ ] I added or updated tests when reasonable.

Approved feedback item (required if not a bug fix or small-scope improvement):

https://yaak.app/feedback/posts/show-global-history

## Related

* https://yaak.app/feedback/posts/save-request-data-for-response-history
* https://yaak.app/feedback/posts/request-body-on-history
* 

## Screenshots

<img width="3882" height="2394" alt="CleanShot 2026-04-25 at 10 45 36@2x" src="https://github.com/user-attachments/assets/377e3148-ef71-4934-a254-a1f741110641" />

<img width="3882" height="2394" alt="CleanShot 2026-04-25 at 10 45 45@2x" src="https://github.com/user-attachments/assets/05733e94-f3d4-485a-afc0-6d0ef4bd9624" />

<img width="3882" height="2394" alt="CleanShot 2026-04-25 at 10 46 35@2x" src="https://github.com/user-attachments/assets/914d5b4b-9dc8-4033-a885-e63ba1784783" />

<img width="2658" height="2160" alt="CleanShot 2026-04-25 at 14 25 42@2x" src="https://github.com/user-attachments/assets/9d7d5eb4-e9de-429b-8dd1-c15239c89d73" />


### Short video


https://github.com/user-attachments/assets/94a8b33a-42d2-4f79-83f0-2c7a6e9bdbe2
