### PR TITLE
fix(importer-curl): read combined short flags as separate options

### DIFF
--- a/plugins/importer-curl/src/index.ts
+++ b/plugins/importer-curl/src/index.ts
@@ -40,6 +40,44 @@ const SUPPORTED_FLAGS = [
 
 const BOOLEAN_FLAGS = ["G", "get", "digest"];
 
+// Short flags that consume a value, derived so this stays in step with the
+// tables above.
+const VALUE_SHORT_FLAGS = SUPPORTED_FLAGS.flat().filter(
+  (name) => name.length === 1 && !BOOLEAN_FLAGS.includes(name),
+);
+
+/**
+ * Expand a short-flag token into separate arguments.
+ *
+ * curl reads a short cluster left to right, one option per character, until an
+ * option that takes a value — that one swallows the rest of the cluster. So
+ * `-XPOST` is `-X POST`, but `-fsSL` is four boolean flags rather than `-f`
+ * plus a value. Splitting unconditionally after the first character left
+ * `sSL` as a positional argument, and the first positional is read as the URL:
+ * `curl -fsSL https://example.com` imported with a URL of `sSL`.
+ */
+function expandShortFlags(token: string): string[] {
+  if (!token.startsWith("-") || token.startsWith("--") || token.length <= 2) {
+    return [token];
+  }
+
+  const expanded: string[] = [];
+  for (let i = 1; i < token.length; i++) {
+    const name = token[i] ?? "";
+    expanded.push(`-${name}`);
+
+    if (VALUE_SHORT_FLAGS.includes(name)) {
+      const value = token.slice(i + 1);
+      if (value) {
+        expanded.push(value);
+      }
+      break;
+    }
+  }
+
+  return expanded;
+}
+
 type FlagValue = string | boolean;
 
 type FlagsByName = Record<string, FlagValue[]>;
@@ -154,14 +192,7 @@ export function convertCurl(rawData: string) {
 
   const commands: string[][] = splitCommands(rawData).map((cmd) => {
     const tokens = split(cmd);
-
-    // Break up squished arguments like `-XPOST` into `-X POST`
-    return tokens.flatMap((token) => {
-      if (token.startsWith("-") && !token.startsWith("--") && token.length > 2) {
-        return [token.slice(0, 2), token.slice(2)];
-      }
-      return token;
-    });
+    return tokens.flatMap(expandShortFlags);
   });
 
   const workspace: ExportResources["workspaces"][0] = {
@@ -502,7 +533,11 @@ function importCommand(parseEntries: string[], workspaceId: string) {
     if (graphqlBody != null) {
       bodyType = "graphql";
       body = graphqlBody;
-    } else if (mimeType === "application/json" || mimeType === "text/xml" || mimeType === "text/plain") {
+    } else if (
+      mimeType === "application/json" ||
+      mimeType === "text/xml" ||
+      mimeType === "text/plain"
+    ) {
       bodyType = mimeType;
       body = { text };
     } else {

--- a/plugins/importer-curl/tests/index.test.ts
+++ b/plugins/importer-curl/tests/index.test.ts
@@ -16,6 +16,36 @@ describe("importer-curl", () => {
     });
   });
 
+  // A short cluster is one option per character until one that takes a value.
+  // `-fsSL` is four boolean flags, so nothing in it is a positional argument --
+  // the URL used to come out as "sSL".
+  test("Imports combined short flags", () => {
+    expect(convertCurl("curl -fsSL https://yaak.app")).toEqual({
+      resources: {
+        workspaces: [baseWorkspace()],
+        httpRequests: [
+          baseRequest({
+            url: "https://yaak.app",
+          }),
+        ],
+      },
+    });
+  });
+
+  test("Imports a combined short cluster ending in a value flag", () => {
+    expect(convertCurl("curl -sSXPOST https://yaak.app")).toEqual({
+      resources: {
+        workspaces: [baseWorkspace()],
+        httpRequests: [
+          baseRequest({
+            url: "https://yaak.app",
+            method: "POST",
+          }),
+        ],
+      },
+    });
+  });
+
   test("Explicit URL", () => {
     expect(convertCurl("curl --url https://yaak.app")).toEqual({
       resources: {


### PR DESCRIPTION
`curl -fsSL https://example.com` imports with a URL of `sSL`. The real URL is dropped.

```
                                    before                         after
curl -fsSL https://yaak.app/x.sh -> "sSL"                       -> "https://yaak.app/x.sh"
curl -sS   https://yaak.app      -> "S"                         -> "https://yaak.app"
curl -L    https://yaak.app      -> "https://yaak.app"          -> unchanged
curl -XPOST https://yaak.app     -> "https://yaak.app"          -> unchanged
```

## Why

The tokenizer split any single-dash token longer than two characters after its first character, assuming a squished value:

```ts
if (token.startsWith("-") && !token.startsWith("--") && token.length > 2) {
  return [token.slice(0, 2), token.slice(2)];
}
```

That is right for `-XPOST` but wrong for a cluster of boolean flags. curl reads a short cluster left to right, one option per character, until an option that *takes* a value — that one swallows the remainder. `-fsSL` is four boolean flags, so splitting after `-f` leaves `sSL` as a positional argument. `-f`, `-s`, `-S` and `-L` are not in `SUPPORTED_FLAGS`, so they are skipped, and `sSL` lands in `singletons` — where `singletons[0]` is read as the URL:

```ts
const urlArg = getPairValue(flagsByName, (singletons[0] as string) || "", ["url"]);
```

`-fsSL` is how most install instructions invoke curl and `-sS` is common in scripts, so a pasted command silently imports a request pointing at a fragment of the flag cluster. Single flags were never affected, which is why the existing cases pass.

## The change

`expandShortFlags` walks the cluster and stops at the first flag that takes a value, which then consumes the rest:

- `-fsSL` → `-f -s -S -L`
- `-XPOST` → `-X POST` (unchanged)
- `-sSXPOST` → `-s -S -X POST`
- `-X` alone → `-X`, so the existing "next token is the value" path still applies

Which short flags take a value is derived rather than restated, so it cannot drift from the tables above it:

```ts
const VALUE_SHORT_FLAGS = SUPPORTED_FLAGS.flat().filter(
  (name) => name.length === 1 && !BOOLEAN_FLAGS.includes(name),
);
```

That resolves to `b d F H X u` today. `importCommand`'s own squished-argument branch is left alone — it no longer sees a squished token from this path, but it is harmless as a second reading.

## Tests

Two cases in `tests/index.test.ts`: a pure boolean cluster, and a cluster ending in a value flag. Negative control — restoring the old splitter fails exactly those two and leaves the other 52 green:

```
 × Imports combined short flags
 × Imports a combined short cluster ending in a value flag
 Tests  2 failed | 52 passed (54)
```

With the fix, `vp test --run tests` in `plugins/importer-curl`: **54 passed (54)**, 2 files. `oxlint` reports nothing for the two changed files.

## Adjacent, not fixed here

An unsupported flag that takes a value still leaves its value as a positional, so `curl -o out.txt https://example.com` imports with the URL `out.txt`. That is the same "first positional becomes the URL" path, but closing it needs a table of curl's value-taking options rather than a parsing rule, so I left it out of this change. Happy to follow up if you want it.

I did not run `vp fmt` — both files already fail `--check` on a clean `main` in my environment (it reports "No config found, using defaults"), so reformatting would have buried the fix in unrelated churn. The pre-commit hook's `vp check --fix` did run over the two staged files.