### PR TITLE
Stop sending scope on the authorization code token request

### DIFF
--- a/plugins/auth-oauth2/src/fetchAccessToken.ts
+++ b/plugins/auth-oauth2/src/fetchAccessToken.ts
@@ -31,7 +31,13 @@ export async function fetchAccessToken(
     ],
   };
 
-  if (scope) httpRequest.body?.form.push({ name: "scope", value: scope });
+  // RFC 6749 §4.1.3 doesn't define scope for the authorization code token
+  // request, so strict servers (OpenIddict) reject it outright. Scope belongs on
+  // the authorize request, which already sends it. Every other grant does define
+  // it: §4.3.2 password, §4.4.2 client credentials, §6 refresh.
+  if (scope && grantType !== "authorization_code") {
+    httpRequest.body?.form.push({ name: "scope", value: scope });
+  }
   if (audience) httpRequest.body?.form.push({ name: "audience", value: audience });
 
   if ("clientAssertion" in args) {

--- a/plugins/auth-oauth2/tests/fetchAccessToken.test.ts
+++ b/plugins/auth-oauth2/tests/fetchAccessToken.test.ts
@@ -1,0 +1,93 @@
+import type { HttpRequest } from "@yaakapp/api";
+import { describe, expect, test } from "vite-plus/test";
+import { fetchAccessToken } from "../src/fetchAccessToken";
+
+/**
+ * Captures the request handed to ctx.httpRequest.send so tests can assert on the
+ * form body, and replies with a minimal successful token response.
+ */
+function createMockContext() {
+  const sent: Partial<HttpRequest>[] = [];
+
+  const ctx = {
+    httpRequest: {
+      async send({ httpRequest }: { httpRequest: Partial<HttpRequest> }) {
+        sent.push(httpRequest);
+        return {
+          httpResponse: { status: 200, error: null },
+          body: {
+            async text() {
+              return JSON.stringify({ access_token: "token-123" });
+            },
+          },
+        };
+      },
+    },
+  } as never;
+
+  return { ctx, sent };
+}
+
+function formNames(httpRequest: Partial<HttpRequest>) {
+  return (httpRequest.body?.form ?? []).map((p: { name: string }) => p.name);
+}
+
+function formValue(httpRequest: Partial<HttpRequest>, name: string) {
+  return (httpRequest.body?.form ?? []).find((p: { name: string }) => p.name === name)?.value;
+}
+
+const baseArgs = {
+  clientId: "client-123",
+  accessTokenUrl: "https://auth.example.com/token",
+  scope: "openid profile",
+  audience: null,
+  clientSecret: "secret",
+  credentialsInBody: true,
+  params: [],
+};
+
+describe("fetchAccessToken scope handling", () => {
+  test("omits scope for the authorization code grant", async () => {
+    const { ctx, sent } = createMockContext();
+
+    await fetchAccessToken(ctx, {
+      ...baseArgs,
+      grantType: "authorization_code",
+      params: [{ name: "code", value: "abc" }],
+    });
+
+    expect(formNames(sent[0]!)).not.toContain("scope");
+    // The rest of the request is untouched
+    expect(formValue(sent[0]!, "grant_type")).toBe("authorization_code");
+    expect(formValue(sent[0]!, "code")).toBe("abc");
+  });
+
+  test("sends scope for the client credentials grant", async () => {
+    const { ctx, sent } = createMockContext();
+
+    await fetchAccessToken(ctx, { ...baseArgs, grantType: "client_credentials" });
+
+    expect(formValue(sent[0]!, "scope")).toBe("openid profile");
+  });
+
+  test("sends scope for the password grant", async () => {
+    const { ctx, sent } = createMockContext();
+
+    await fetchAccessToken(ctx, { ...baseArgs, grantType: "password" });
+
+    expect(formValue(sent[0]!, "scope")).toBe("openid profile");
+  });
+
+  test("still sends audience for the authorization code grant", async () => {
+    const { ctx, sent } = createMockContext();
+
+    await fetchAccessToken(ctx, {
+      ...baseArgs,
+      grantType: "authorization_code",
+      audience: "https://api.example.com",
+    });
+
+    expect(formValue(sent[0]!, "audience")).toBe("https://api.example.com");
+    expect(formNames(sent[0]!)).not.toContain("scope");
+  });
+});


### PR DESCRIPTION
## Summary

The OAuth 2 plugin sent `scope` on the authorization code token request as well as the authorize request. RFC 6749 [§4.1.3](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3) does not define `scope` for that request, so strict servers such as OpenIddict reject the exchange outright. Scope is now omitted there, and still sent on the authorize request where it belongs.

Other grants are unaffected. Password ([§4.3.2](https://datatracker.ietf.org/doc/html/rfc6749#section-4.3.2)), client credentials ([§4.4.2](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.2)), and refresh ([§6](https://datatracker.ietf.org/doc/html/rfc6749#section-6)) all define `scope` and continue to send it.

The guard lives in `fetchAccessToken` keyed on `grantType`, rather than at the `authorizationCode` call site, so no future caller can reintroduce it.

## Submission

- [x] This PR is a bug fix.
- [ ] If this PR is not a bug fix, I linked the feedback item where @gschier explicitly gave me permission to work on it.
- [x] I have read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
- [x] I tested this change locally.
- [x] I added or updated tests, or tests are not reasonable for this change.
- [x] I added screenshots or recordings, or this change does not affect the UI.

Explicit permission feedback item (required if not a bug fix):

<!-- Not applicable, this is a bug fix. -->

## Related

Reported in [OAuth 2 scope should only be sent on authorize](https://yaak.app/feedback/posts/oauth-2-scope-should-only-be-sent-on-authorize).

## Testing

Four tests added in `plugins/auth-oauth2/tests/fetchAccessToken.test.ts`, covering scope omitted for authorization code, scope still sent for client credentials and password, and audience still sent for authorization code.

The two authorization code tests were confirmed to fail with the guard removed, so they genuinely cover the fix. Full plugin suite passes at 28 tests.

One judgement call worth noting: this removes `scope` unconditionally rather than adding an opt-out. That matches the spec and the reporter's preferred option, but a non-conformant server that relies on receiving `scope` there would regress.
