### PR TITLE
Render all columns in irregular CSV responses

### DIFF
--- a/apps/yaak-client/components/responseViewers/CsvViewer.test.tsx
+++ b/apps/yaak-client/components/responseViewers/CsvViewer.test.tsx
@@ -27,5 +27,6 @@ describe("CsvViewer", () => {
 
     expect(markup).toContain("ID de usuario");
     expect(markup).toContain("42041");
+    expect(markup.match(/<td>/g)).toHaveLength(20);
   });
 });

--- a/apps/yaak-client/components/responseViewers/CsvViewer.test.tsx
+++ b/apps/yaak-client/components/responseViewers/CsvViewer.test.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test, vi } from "vite-plus/test";
+import { CsvViewerInner } from "./CsvViewer";
+
+vi.mock("@yaakapp-internal/ui", () => ({
+  Table: ({ children }: { children: ReactNode }) => <table>{children}</table>,
+  TableBody: ({ children }: { children: ReactNode }) => <tbody>{children}</tbody>,
+  TableCell: ({ children }: { children: ReactNode }) => <td>{children}</td>,
+  TableHead: ({ children }: { children: ReactNode }) => <thead>{children}</thead>,
+  TableHeaderCell: ({ children }: { children: ReactNode }) => <th>{children}</th>,
+  TableRow: ({ children }: { children: ReactNode }) => <tr>{children}</tr>,
+}));
+
+describe("CsvViewer", () => {
+  test("renders columns that extend beyond the first row", () => {
+    const markup = renderToStaticMarkup(
+      <CsvViewerInner
+        text={[
+          "startDate,2026-02-03T00:00-03:00",
+          "endDate,2026-02-03T23:59:59-03:00",
+          "id,Fecha de inicio,Nombre,Estado,Perfil de puesto,ID de sucursal,Sucursal,Fecha de fin,ID de usuario",
+          "391118210,2026-02-03 12:58:55,atencion1,Disponible,ATD,3549,sucursal,2026-02-03 12:59:08,42041",
+        ].join("\n")}
+      />,
+    );
+
+    expect(markup).toContain("ID de usuario");
+    expect(markup).toContain("42041");
+  });
+});

--- a/apps/yaak-client/components/responseViewers/CsvViewer.tsx
+++ b/apps/yaak-client/components/responseViewers/CsvViewer.tsx
@@ -26,27 +26,32 @@ export function CsvViewer({ text, className }: Props) {
 export function CsvViewerInner({ text, className }: { text: string | null; className?: string }) {
   const parsed = useMemo(() => {
     if (text == null) return null;
-    return Papa.parse<Record<string, string>>(text, { header: true, skipEmptyLines: true });
+    return Papa.parse<string[]>(text, { skipEmptyLines: true });
   }, [text]);
 
   if (parsed === null) return null;
+
+  const header = parsed.data[0] ?? [];
+  const rows = parsed.data.slice(1);
+  const columnCount = parsed.data.reduce((count, row) => Math.max(count, row.length), 0);
+  const columnIndexes = Array.from({ length: columnCount }, (_, index) => index);
 
   return (
     <div className="overflow-auto h-full">
       <Table className={classNames(className, "text-sm")}>
         <TableHead>
           <TableRow>
-            {parsed.meta.fields?.map((field) => (
-              <TableHeaderCell key={field}>{field}</TableHeaderCell>
+            {columnIndexes.map((columnIndex) => (
+              <TableHeaderCell key={columnIndex}>{header[columnIndex] ?? ""}</TableHeaderCell>
             ))}
           </TableRow>
         </TableHead>
         <TableBody>
-          {parsed.data.map((row, i) => (
+          {rows.map((row, i) => (
             // oxlint-disable-next-line react/no-array-index-key
             <TableRow key={i}>
-              {parsed.meta.fields?.map((key) => (
-                <TableCell key={key}>{row[key] ?? ""}</TableCell>
+              {columnIndexes.map((columnIndex) => (
+                <TableCell key={columnIndex}>{row[columnIndex] ?? ""}</TableCell>
               ))}
             </TableRow>
           ))}

--- a/apps/yaak-client/components/responseViewers/CsvViewer.tsx
+++ b/apps/yaak-client/components/responseViewers/CsvViewer.tsx
@@ -50,8 +50,9 @@ export function CsvViewerInner({ text, className }: { text: string | null; class
           {rows.map((row, i) => (
             // oxlint-disable-next-line react/no-array-index-key
             <TableRow key={i}>
-              {columnIndexes.map((columnIndex) => (
-                <TableCell key={columnIndex}>{row[columnIndex] ?? ""}</TableCell>
+              {row.map((cell, columnIndex) => (
+                // oxlint-disable-next-line react/no-array-index-key
+                <TableCell key={columnIndex}>{cell}</TableCell>
               ))}
             </TableRow>
           ))}


### PR DESCRIPTION
## Summary

- parse CSV responses as row arrays while continuing to use Papa Parse
- size the rendered table from the widest row and pad shorter rows
- add a regression test for metadata rows followed by wider tabular data

## Why

The CSV viewer previously treated the first row as the complete field schema. Responses with narrow metadata rows before wider records therefore rendered only the first columns and silently hid the remaining values.

Fixes [Missing output in the response window](https://yaak.app/feedback/posts/missing-output-in-the-response-window).

## Testing

- `npm run lint --workspace @yaakapp/yaak-client`
- `npx vp test apps/yaak-client --run` (397 tests)