### PR TITLE
Preserve base URL variable when OpenAPI servers are omitted

### DIFF
--- a/plugins/importer-openapi/src/index.ts
+++ b/plugins/importer-openapi/src/index.ts
@@ -63,20 +63,20 @@ export async function convertOpenApi(contents: string): Promise<ImportPluginResp
     httpRequests: [],
   };
   const baseUrl = importBaseUrl(spec);
-  const requestBaseUrl = baseUrl.length > 0 ? "${[baseUrl]}" : "";
-
-  if (baseUrl.length > 0) {
-    resources.environments.push({
-      model: "environment",
-      id: importState.generateId("environment"),
-      workspaceId: workspace.id,
-      name: "Global Variables",
-      variables: [{ name: "baseUrl", value: baseUrl }],
-      parentModel: "workspace",
-      parentId: null,
-      sortPriority: importState.nextSortPriority(),
-    });
-  }
+  // A local spec has no document URL against which OpenAPI's implicit "/"
+  // server can resolve. Keep the shared variable even when its initial value
+  // is empty so users can configure the host once instead of editing requests.
+  const requestBaseUrl = "${[baseUrl]}";
+  resources.environments.push({
+    model: "environment",
+    id: importState.generateId("environment"),
+    workspaceId: workspace.id,
+    name: "Global Variables",
+    variables: [{ name: "baseUrl", value: baseUrl }],
+    parentModel: "workspace",
+    parentId: null,
+    sortPriority: importState.nextSortPriority(),
+  });
 
   const folderIdsByTag = new Map<string, string>();
   const routeLabels = new Map<string, string>();

--- a/plugins/importer-openapi/tests/index.test.ts
+++ b/plugins/importer-openapi/tests/index.test.ts
@@ -229,6 +229,26 @@ describe("importer-openapi", () => {
     expect(imported).toBeUndefined();
   });
 
+  test("Creates an editable baseUrl variable when OpenAPI omits servers", async () => {
+    const imported = await convertOpenApi(
+      JSON.stringify({
+        openapi: "3.0.4",
+        info: { title: "Serverless OpenAPI Test", version: "1.0.0" },
+        paths: {
+          "/api/widgets": { get: { responses: {} } },
+        },
+      }),
+    );
+
+    expect(imported?.resources.environments).toEqual([
+      expect.objectContaining({
+        name: "Global Variables",
+        variables: [{ name: "baseUrl", value: "" }],
+      }),
+    ]);
+    expect(imported?.resources.httpRequests[0]?.url).toBe("${[baseUrl]}/api/widgets");
+  });
+
   test("Prefers operation and path servers over the spec base URL", async () => {
     const imported = await convertOpenApi(
       JSON.stringify({


### PR DESCRIPTION
## Summary

- create a shared `baseUrl` variable even when the document omits `servers`
- build imported request URLs from that variable so the host can be configured once
- cover the OpenAPI 3.0.4/Swashbuckle shape with a regression test

## Root cause

The native rewrite only created and referenced `baseUrl` when it could initialize it from the document. For documents that rely on OpenAPI's implicit root server, it emitted bare paths and left no shared place to configure the host.

Feedback: [OpenApi import does not add BASE_URL to URLs](https://yaak.app/feedback/posts/openapi-import-does-not-add-base_url-to-urls)

## Validation

- `vp test --run tests/index.test.ts`
- `oxlint --type-aware src/index.ts tests/index.test.ts`
- `yaakcli build`