### PR TITLE
Support OpenAPI 3.2 QUERY and additional operations

### DIFF
--- a/plugins/importer-openapi/src/index.ts
+++ b/plugins/importer-openapi/src/index.ts
@@ -21,7 +21,7 @@ type ImportResources = {
   httpRequests: AtLeast<HttpRequest, "name" | "id" | "model" | "workspaceId">[];
 };
 
-const HTTP_METHODS = ["delete", "get", "head", "options", "patch", "post", "put", "trace"];
+const HTTP_METHODS = ["delete", "get", "head", "options", "patch", "post", "put", "query", "trace"];
 const BODY_CONTENT_TYPE_PREFERENCE = [
   "application/json",
   "application/x-www-form-urlencoded",
@@ -103,10 +103,7 @@ export async function convertOpenApi(contents: string): Promise<ImportPluginResp
     if (!isRecord(pathItem)) continue;
 
     const pathParameters = toArray(pathItem.parameters);
-    for (const method of HTTP_METHODS) {
-      const operation = importState.resolve(pathItem[method]);
-      if (!isRecord(operation)) continue;
-
+    for (const { method, operation } of pathItemOperations(pathItem, importState)) {
       const folderId = findOrCreateFolderId({
         folderIdsByTag,
         importState,
@@ -148,6 +145,24 @@ export async function convertOpenApi(contents: string): Promise<ImportPluginResp
       }),
     ) as PartialImportResources,
   };
+}
+
+/** OpenAPI 3.2 adds QUERY plus a map for extension HTTP methods. */
+function pathItemOperations(
+  pathItem: UnknownRecord,
+  importState: ImportState,
+): { method: string; operation: UnknownRecord }[] {
+  const operations = HTTP_METHODS.flatMap((method) => {
+    const operation = importState.resolve(pathItem[method]);
+    return isRecord(operation) ? [{ method, operation }] : [];
+  });
+
+  for (const [method, rawOperation] of Object.entries(toRecord(pathItem.additionalOperations))) {
+    if (HTTP_METHODS.includes(method.toLowerCase())) continue;
+    const operation = importState.resolve(rawOperation);
+    if (isRecord(operation)) operations.push({ method, operation });
+  }
+  return operations;
 }
 
 /**

--- a/plugins/importer-openapi/tests/index.test.ts
+++ b/plugins/importer-openapi/tests/index.test.ts
@@ -13,6 +13,28 @@ describe("importer-openapi", () => {
     .readdirSync(realWorldFixturesPath)
     .filter((fixture) => fixture.endsWith(".yaml"));
 
+  test("Imports OpenAPI 3.2 QUERY and additional operations", async () => {
+    const imported = await convertOpenApi(
+      JSON.stringify({
+        openapi: "3.2.0",
+        info: { title: "OpenAPI 3.2 Operations", version: "1.0.0" },
+        paths: {
+          "/resources": {
+            query: { summary: "Query resources", responses: {} },
+            additionalOperations: {
+              COPY: { summary: "Copy resources", responses: {} },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(imported?.resources.httpRequests).toEqual([
+      expect.objectContaining({ method: "QUERY", name: "Query resources", url: "/resources" }),
+      expect.objectContaining({ method: "COPY", name: "Copy resources", url: "/resources" }),
+    ]);
+  });
+
   test("Maps operation description to request description", async () => {
     const imported = await convertOpenApi(
       JSON.stringify({


### PR DESCRIPTION
## Summary

- import the OpenAPI 3.2 `QUERY` operation
- import custom HTTP methods declared through `additionalOperations`
- add a regression spec whose only requests use the new 3.2 fields

## Root cause

Version detection accepted every OpenAPI 3.x document, but path traversal was hard-coded to the older HTTP method fields. A valid 3.2 document could therefore import as empty.

## Validation

- `vp test --run tests/index.test.ts`
- `oxlint --type-aware src/index.ts tests/index.test.ts`
- `yaakcli build`