### PR TITLE
fix(copy-as): emit shell-safe arguments in the curl and gRPCurl exporters

### DIFF
--- a/plugins/action-copy-curl/src/index.ts
+++ b/plugins/action-copy-curl/src/index.ts
@@ -83,7 +83,9 @@ export async function convertToCurl(request: Partial<HttpRequest>) {
       if (p.file) {
         let v = `${p.name}=@${p.file}`;
         v += p.contentType ? `;type=${p.contentType}` : "";
-        xs.push(flag, v);
+        // A bare `;` separates commands and a path can hold spaces, so this
+        // argument needs quoting like every other one.
+        xs.push(flag, quote(v));
       } else {
         xs.push(flag, quote(`${p.name}=${p.value}`));
       }
@@ -157,7 +159,10 @@ export async function convertToCurl(request: Partial<HttpRequest>) {
 }
 
 function quote(arg: string): string {
-  const escaped = arg.replace(/'/g, "\\'");
+  // A single-quoted POSIX string takes no escapes, so `\'` does not close it:
+  // the string ends one character early and the rest of the command is left
+  // dangling. Step out of the quotes, emit an escaped quote, step back in.
+  const escaped = arg.replace(/'/g, `'\\''`);
   return `'${escaped}'`;
 }
 

--- a/plugins/action-copy-curl/tests/index.test.ts
+++ b/plugins/action-copy-curl/tests/index.test.ts
@@ -120,7 +120,7 @@ describe("exporter-curl", () => {
         `curl -X PUT 'https://yaak.app'`,
         `--form 'a=aaa'`,
         `--form 'b=bbb'`,
-        "--form f=@/foo/bar.png;type=image/png",
+        "--form 'f=@/foo/bar.png;type=image/png'",
       ].join(" \\\n  "),
     );
   });
@@ -140,11 +140,48 @@ describe("exporter-curl", () => {
       [
         `curl -X POST 'https://yaak.app'`,
         `--header 'Content-Type: application/json'`,
-        `--data '{"foo":"bar\\'s"}'`,
+        `--data '{"foo":"bar'\\''s"}'`,
       ].join(" \\\n  "),
     );
   });
 
+  test("Quotes an apostrophe so the command still parses", async () => {
+    // POSIX single quotes take no escapes: `\'` ends the string one
+    // character early and everything after it is left dangling, so the copied
+    // command is a syntax error rather than a request.
+    const command = await convertToCurl({
+      url: "https://yaak.app/it's",
+      method: "POST",
+      bodyType: "application/json",
+      body: { text: `{"note":"don't stop"}` },
+      headers: [{ name: "X-Note", value: "it's fine" }],
+    });
+
+    expect(command).toEqual(
+      [
+        `curl -X POST 'https://yaak.app/it'\\''s'`,
+        `--header 'X-Note: it'\\''s fine'`,
+        `--data '{"note":"don'\\''t stop"}'`,
+      ].join(" \\\n  "),
+    );
+  });
+
+  test("Quotes a file form field so its type suffix survives", async () => {
+    // A bare `;` separates commands, so an unquoted `f=@x.png;type=image/png`
+    // reaches curl as `f=@x.png` and the rest runs as its own command.
+    expect(
+      await convertToCurl({
+        url: "https://yaak.app",
+        method: "POST",
+        bodyType: "multipart/form-data",
+        body: { form: [{ name: "f", file: "/my files/a.png", contentType: "image/png" }] },
+      }),
+    ).toEqual(
+      [`curl -X POST 'https://yaak.app'`, `--form 'f=@/my files/a.png;type=image/png'`].join(
+        " \\\n  ",
+      ),
+    );
+  });
   test("Exports multi-line JSON body", async () => {
     expect(
       await convertToCurl({

--- a/plugins/action-copy-grpcurl/src/index.ts
+++ b/plugins/action-copy-grpcurl/src/index.ts
@@ -129,7 +129,10 @@ export async function convert(request: Partial<GrpcRequest>, allProtoFiles: stri
 }
 
 function quote(arg: string): string {
-  const escaped = arg.replace(/'/g, "\\'");
+  // A single-quoted POSIX string takes no escapes, so `\'` does not close it:
+  // the string ends one character early and the rest of the command is left
+  // dangling. Step out of the quotes, emit an escaped quote, step back in.
+  const escaped = arg.replace(/'/g, `'\\''`);
   return `'${escaped}'`;
 }
 

--- a/plugins/action-copy-grpcurl/tests/index.test.ts
+++ b/plugins/action-copy-grpcurl/tests/index.test.ts
@@ -175,4 +175,21 @@ describe("exporter-curl", () => {
       ].join(" \\\n  "),
     );
   });
+
+  test("Quotes an apostrophe so the command still parses", async () => {
+    // POSIX single quotes take no escapes: `\'` ends the string one
+    // character early and leaves the rest of the command dangling.
+    const command = await convert(
+      {
+        url: "https://yaak.app",
+        service: "Service",
+        method: "Method",
+        message: `{"note":"don't stop"}`,
+        metadata: [{ name: "x-note", value: "it's fine" }],
+      },
+      [],
+    );
+    expect(command).toContain(`'{"note":"don'\\''t stop"}'`);
+    expect(command).toContain(`'x-note: it'\\''s fine'`);
+  });
 });


### PR DESCRIPTION
## Summary

`quote()` escaped `'` as `\'`, which a POSIX shell does not read as an escape inside single quotes, so any request whose URL, header, body or credentials contain an apostrophe copied out as a command the shell refuses to parse. The curl exporter also pushed file form fields unquoted, so a bare `;` before the type suffix cut the argument short. Both exporters now emit shell-safe arguments.

## Submission

- [x] This PR is a bug fix.
- [ ] If this PR is not a bug fix, I linked the feedback item where @gschier explicitly gave me permission to work on it.
- [x] I have read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
- [x] I tested this change locally.
- [x] I added or updated tests, or tests are not reasonable for this change.
- [x] I added screenshots or recordings, or this change does not affect the UI.

## Related

No linked issue — found while reading the exporters.

---

## Apostrophes

Inside a single-quoted POSIX string a backslash is an ordinary character, not an escape, so the string ends one character early and the rest of the command is left dangling:

```
$ printf '%s\n' '{"foo":"bar\'s"}'
bash: unexpected EOF while looking for matching `"'
```

The POSIX idiom is to leave the quoted run, emit an escaped quote, and start a new one — `'\''`:

```
$ printf '%s\n' '{"foo":"bar'\''s"}'
{"foo":"bar's"}
```

`action-copy-grpcurl` carries its own copy of the same `quote()`, so a message body or metadata value with an apostrophe failed the same way. Both are fixed.

## File form fields

The `p.file` branch in the curl exporter pushed its value unquoted. A bare `;` is a command separator, so the type suffix never reached curl at all — and a path with spaces was split on top of that:

```
$ showargs --form f=@/foo/bar.png;type=image/png
ARG[--form]
ARG[f=@/foo/bar.png]          # type=image/png ran as its own command

$ showargs --form 'f=@/foo/bar.png;type=image/png'
ARG[--form]
ARG[f=@/foo/bar.png;type=image/png]
```

It now goes through `quote()` like every other argument.

## Tests

Two existing curl expectations encoded the broken output (`--data '{"foo":"bar\'s"}'` and `--form f=@/foo/bar.png;type=image/png`), so they move with the behaviour. New cases cover an apostrophe across URL, header and body, a file field with both a space in the path and a type suffix, and the gRPCurl message/metadata path.

- Ran: `npm test` in `plugins/action-copy-curl` — 30 passed, 0 failed.
- Ran: `npm test` in `plugins/action-copy-grpcurl` — 14 passed, 0 failed.
- Checked: fed the real output of `convertToCurl` to bash with `curl` stubbed as an argument printer. Every value arrives intact:

```
curl -X POST 'https://yaak.app/it'\''s' \
  --header 'X-Note: it'\''s fine' \
  --form 'f=@/my files/a.png;type=image/png'

ARG[https://yaak.app/it's]
ARG[X-Note: it's fine]
ARG[f=@/my files/a.png;type=image/png]
```

Before the change the same request produced a command bash refuses to parse.