### PR TITLE
Align OpenAPI 3.2 URL expectations with base URL variables

### DIFF
--- a/plugins/importer-openapi/tests/index.test.ts
+++ b/plugins/importer-openapi/tests/index.test.ts
@@ -30,8 +30,16 @@ describe("importer-openapi", () => {
     );
 
     expect(imported?.resources.httpRequests).toEqual([
-      expect.objectContaining({ method: "QUERY", name: "Query resources", url: "/resources" }),
-      expect.objectContaining({ method: "COPY", name: "Copy resources", url: "/resources" }),
+      expect.objectContaining({
+        method: "QUERY",
+        name: "Query resources",
+        url: "${[baseUrl]}/resources",
+      }),
+      expect.objectContaining({
+        method: "COPY",
+        name: "Copy resources",
+        url: "${[baseUrl]}/resources",
+      }),
     ]);
   });
 


### PR DESCRIPTION
## Summary

- update the OpenAPI 3.2 operation regression to expect the shared `baseUrl` variable
- restore the importer suite after PRs #585 and #591 were merged together
- provide a clean shared base for the remaining importer fix stacks

## Root cause

PR #585 intentionally changed server-less imports from bare paths to `${[baseUrl]}` URLs. PR #591 was developed in parallel and added expectations for the old bare-path behavior, so the two individually green PRs left `main` with one failing importer test after both merged.

## Review order

Review and merge this prerequisite first. Afterward, #586, #588, and #590 can proceed independently.

## Validation

- `vp test --run tests/index.test.ts` (22 passed)
- `oxlint --type-aware tests/index.test.ts`
- `oxfmt --check tests/index.test.ts`