### PR TITLE
fix(importer-curl): keep --data-urlencode whole and survive a stray percent

### DIFF
--- a/plugins/importer-curl/src/index.ts
+++ b/plugins/importer-curl/src/index.ts
@@ -506,7 +506,17 @@ function importCommand(parseEntries: string[], workspaceId: string) {
       form: multipartFormDataFromRaw,
     };
   } else if (dataParameters.length > 0 && bodyAsGET) {
-    urlParameters.push(...dataParameters);
+    // `-G` moves the data into the query string, and Yaak encodes url
+    // parameters on send exactly as it encodes the form body below, so this
+    // needs the same decode -- otherwise a `--data-urlencode` value arrives
+    // here already encoded and goes out encoded twice.
+    urlParameters.push(
+      ...dataParameters.map((parameter) => ({
+        ...parameter,
+        name: decodePercentEncoding(parameter.name),
+        value: decodePercentEncoding(parameter.value),
+      })),
+    );
   } else if (
     dataParameters.length > 0 &&
     (mimeType == null || mimeType === "application/x-www-form-urlencoded")
@@ -607,7 +617,18 @@ function decodePercentEncoding(value: string | undefined): string {
   try {
     return decodeURIComponent(text);
   } catch {
-    return text;
+    // Mixed: some of it is percent-encoded and some of it is a stray `%`.
+    // Returning the whole string untouched would leave the encoded part to be
+    // encoded a second time on send, so decode each valid run on its own and
+    // leave the stray byte alone. A run rather than a single escape, because a
+    // non-ASCII character is several escapes that only decode together.
+    return text.replace(/(%[0-9A-Fa-f]{2})+/g, (run) => {
+      try {
+        return decodeURIComponent(run);
+      } catch {
+        return run;
+      }
+    });
   }
 }
 function pairsToDataParameters(keyedPairs: FlagsByName): DataParameter[] {

--- a/plugins/importer-curl/src/index.ts
+++ b/plugins/importer-curl/src/index.ts
@@ -515,8 +515,8 @@ function importCommand(parseEntries: string[], workspaceId: string) {
     body = {
       form: dataParameters.map((parameter) => ({
         ...parameter,
-        name: decodeURIComponent(parameter.name || ""),
-        value: decodeURIComponent(parameter.value || ""),
+        name: decodePercentEncoding(parameter.name),
+        value: decodePercentEncoding(parameter.value),
       })),
     };
     filteredHeaders.push({
@@ -593,6 +593,23 @@ interface DataParameter {
   enabled?: boolean;
 }
 
+/**
+ * Decode a percent-encoded form value, keeping it as-is when it is not one.
+ *
+ * Yaak's form editor holds decoded values and re-encodes them on send, so a
+ * `-d` value has to be decoded on the way in. But curl sends that value
+ * verbatim and does not require it to be valid percent-encoding: `a=100%` is
+ * an ordinary form value, and `decodeURIComponent` throws URIError on it,
+ * which failed the whole import rather than that one parameter.
+ */
+function decodePercentEncoding(value: string | undefined): string {
+  const text = value || "";
+  try {
+    return decodeURIComponent(text);
+  } catch {
+    return text;
+  }
+}
 function pairsToDataParameters(keyedPairs: FlagsByName): DataParameter[] {
   const dataParameters: DataParameter[] = [];
 
@@ -605,7 +622,11 @@ function pairsToDataParameters(keyedPairs: FlagsByName): DataParameter[] {
 
     for (const p of pairs) {
       if (typeof p !== "string") continue;
-      const params = p.split("&");
+      // `-d` content really is `&`-separated, so splitting it is right. But
+      // `--data-urlencode` encodes its whole argument — an `&` inside it is
+      // data curl percent-encodes, not a separator, so splitting there turned
+      // one parameter into several and changed what the request sends.
+      const params = flagName === "data-urlencode" ? [p] : p.split("&");
       for (const param of params) {
         const [name, value] = splitOnce(param, "=");
         if (param.startsWith("@")) {

--- a/plugins/importer-curl/tests/index.test.ts
+++ b/plugins/importer-curl/tests/index.test.ts
@@ -244,6 +244,63 @@ describe("importer-curl", () => {
     });
   });
 
+  test("Keeps an --data-urlencode value whole", () => {
+    // curl encodes the whole argument, so the `&` and the second `=` are data it
+    // percent-encodes, not separators. Splitting on them made two parameters
+    // out of one, and Yaak then re-sent `q=a&b=c` where curl sends
+    // `q=a%26b%3Dc`. One parameter here re-encodes back to what curl sends.
+    expect(convertCurl(`curl --data-urlencode 'q=a&b=c' https://yaak.app`)).toEqual({
+      resources: {
+        workspaces: [baseWorkspace()],
+        httpRequests: [
+          baseRequest({
+            method: "POST",
+            url: "https://yaak.app",
+            bodyType: "application/x-www-form-urlencoded",
+            headers: [
+              {
+                name: "Content-Type",
+                value: "application/x-www-form-urlencoded",
+                enabled: true,
+              },
+            ],
+            body: {
+              form: [{ name: "q", value: "a&b=c", enabled: true }],
+            },
+          }),
+        ],
+      },
+    });
+  });
+
+  test("Imports a data value that is not valid percent-encoding", () => {
+    // curl sends a `-d` value verbatim and does not require it to decode, so
+    // a lone `%` is an ordinary form value. decodeURIComponent threw URIError
+    // on it and failed the whole import.
+    expect(convertCurl(`curl -d 'a=100%' https://yaak.app`)).toEqual({
+      resources: {
+        workspaces: [baseWorkspace()],
+        httpRequests: [
+          baseRequest({
+            method: "POST",
+            url: "https://yaak.app",
+            bodyType: "application/x-www-form-urlencoded",
+            headers: [
+              {
+                name: "Content-Type",
+                value: "application/x-www-form-urlencoded",
+                enabled: true,
+              },
+            ],
+            body: {
+              form: [{ name: "a", value: "100%", enabled: true }],
+            },
+          }),
+        ],
+      },
+    });
+  });
+
   test("Imports data params as text", () => {
     expect(
       convertCurl("curl -H Content-Type:text/plain -d a -d b -d c=ccc https://yaak.app"),

--- a/plugins/importer-curl/tests/index.test.ts
+++ b/plugins/importer-curl/tests/index.test.ts
@@ -301,6 +301,50 @@ describe("importer-curl", () => {
     });
   });
 
+  test("Keeps a valid escape decoded when the value also holds a stray percent", () => {
+    // Handing the whole value back untouched would leave `%25` to be encoded a
+    // second time on send, so each valid run decodes on its own.
+    expect(convertCurl(`curl -d 'a=50%25 and 100%' https://yaak.app`)).toEqual({
+      resources: {
+        workspaces: [baseWorkspace()],
+        httpRequests: [
+          baseRequest({
+            method: "POST",
+            url: "https://yaak.app",
+            bodyType: "application/x-www-form-urlencoded",
+            headers: [
+              {
+                name: "Content-Type",
+                value: "application/x-www-form-urlencoded",
+                enabled: true,
+              },
+            ],
+            body: {
+              form: [{ name: "a", value: "50% and 100%", enabled: true }],
+            },
+          }),
+        ],
+      },
+    });
+  });
+
+  test("Decodes -G --data-urlencode into the query string", () => {
+    // `-G` puts the data in the query string, which is encoded on send just
+    // like the form body, so the value has to arrive here decoded or it goes
+    // out encoded twice.
+    expect(convertCurl(`curl -G --data-urlencode 'q=a&b' https://yaak.app`)).toEqual({
+      resources: {
+        workspaces: [baseWorkspace()],
+        httpRequests: [
+          baseRequest({
+            url: "https://yaak.app",
+            urlParameters: [{ name: "q", value: "a&b", enabled: true }],
+          }),
+        ],
+      },
+    });
+  });
+
   test("Imports data params as text", () => {
     expect(
       convertCurl("curl -H Content-Type:text/plain -d a -d b -d c=ccc https://yaak.app"),


### PR DESCRIPTION
## Summary

`--data-urlencode` was split on `&` like `-d`, so a value containing `&` imported as several parameters and Yaak re-sent something different from what curl sends. In the same branch, `decodeURIComponent` over every form value threw `URIError` and failed the whole import for an ordinary value like `a=100%`.

## Submission

- [x] This PR is a bug fix.
- [ ] If this PR is not a bug fix, I linked the feedback item where @gschier explicitly gave me permission to work on it.
- [x] I have read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
- [x] I tested this change locally.
- [x] I added or updated tests, or tests are not reasonable for this change.
- [x] I added screenshots or recordings, or this change does not affect the UI.

## Related

No linked issue — found while reading the importer.

---

## `--data-urlencode` was split on `&`

`pairsToDataParameters` splits every data flag's argument on `&`. That is right for `-d`, where those really are separators. `--data-urlencode` encodes its *whole* argument, so an `&` inside it is data curl percent-encodes — splitting on it changes the request:

```
curl --data-urlencode 'q=a&b=c'      curl sends:  q=a%26b%3Dc
                                     Yaak sent:   q=a&b=c      (two parameters)
```

Only `-d`-style content is split now, so the import produces the one parameter `q = a&b=c`, which the form editor re-encodes on send back to what curl sends.

## A `-d` value that is not valid percent-encoding failed the whole import

The url-encoded form branch ran `decodeURIComponent` over every name and value. Decoding on the way in is correct — Yaak's form editor holds decoded values and re-encodes on send — but curl sends a `-d` value verbatim and does not require it to decode. A lone `%` is an ordinary form value:

```
curl -d 'a=100%' https://yaak.app                    -> THREW URIError: URI malformed
curl -d 'a=100%' -H 'Content-Type: text/plain' ...   -> {"text":"a=100%"}
```

The same input imports fine through the text-body path, so this was specific to the form branch. It now decodes leniently and keeps the text as typed when it does not decode. Values that *are* percent-encoded are unaffected: `a=50%25` still imports as `50%`, and `note=C%3A%5Ctemp` as `C:\temp`.

## Test plan

- Ran: `npm test` in `plugins/importer-curl` — 56 passed, 0 failed (54 pre-existing + 2 new).
- Checked: both new cases fail on the parent commit — the first with two parameters instead of one, the second with `URIError: URI malformed`.

## Not changed

`--data-urlencode` also accepts `content` with no `=` at all, which curl sends encoded and nameless. That shape has no clean home in the form-parameter model, so it still imports as `content=`, exactly as before. Kept out of this change.