### PR TITLE
Qualify namespaced OpenAPI XML attributes

### DIFF
--- a/plugins/importer-openapi/src/index.ts
+++ b/plugins/importer-openapi/src/index.ts
@@ -1164,17 +1164,31 @@ function valueToXml(
   }
   if (isRecord(value)) {
     const properties = toRecord(resolvedSchema.properties);
+    const entries = Object.entries(value).map(([name, propertyValue]) => {
+      const propertySchema = toRecord(importState.resolve(properties[name]));
+      return { name, propertyValue, propertySchema, xml: toRecord(propertySchema.xml) };
+    });
+    const usedPrefixes = new Set(["xml", "xmlns"]);
+    const prefixesByNamespace = new Map<string, string>();
+    for (const xml of [schemaXml, ...entries.map(({ xml }) => xml)]) {
+      const namespace = stringAt(xml, "namespace");
+      const prefix = stringAt(xml, "prefix");
+      if (prefix == null || prefix.length === 0) continue;
+      usedPrefixes.add(prefix);
+      if (namespace != null && !prefixesByNamespace.has(namespace)) {
+        prefixesByNamespace.set(namespace, prefix);
+      }
+    }
     const attributes: string[] = [];
     const attributeNamespaces: UnknownRecord[] = [];
     const children: string[] = [];
-    for (const [name, propertyValue] of Object.entries(value)) {
-      const propertySchema = toRecord(importState.resolve(properties[name]));
-      const xml = toRecord(propertySchema.xml);
+    for (const { name, propertyValue, propertySchema, xml } of entries) {
       if (xml.attribute === true) {
+        const attributeXml = qualifyXmlAttribute(xml, usedPrefixes, prefixesByNamespace);
         attributes.push(
-          `${qualifiedXmlName(name, xml)}="${escapeXml(stringifyExampleValue(propertyValue))}"`,
+          `${qualifiedXmlName(name, attributeXml)}="${escapeXml(stringifyExampleValue(propertyValue))}"`,
         );
-        attributeNamespaces.push(xml);
+        attributeNamespaces.push(attributeXml);
       } else {
         children.push(valueToXml(propertyValue, propertySchema, importState, name));
       }
@@ -1205,6 +1219,26 @@ function xmlElement(
   const attributeText = [...namespaceAttributes, ...attributes].join(" ");
   const openingTag = attributeText.length > 0 ? `<${name} ${attributeText}>` : `<${name}>`;
   return `${openingTag}${content}</${name}>`;
+}
+
+function qualifyXmlAttribute(
+  xml: UnknownRecord,
+  usedPrefixes: Set<string>,
+  prefixesByNamespace: Map<string, string>,
+): UnknownRecord {
+  const namespace = stringAt(xml, "namespace");
+  const declaredPrefix = stringAt(xml, "prefix");
+  if (namespace == null || (declaredPrefix != null && declaredPrefix.length > 0)) return xml;
+
+  const existingPrefix = prefixesByNamespace.get(namespace);
+  if (existingPrefix != null) return { ...xml, prefix: existingPrefix };
+
+  let suffix = 1;
+  while (usedPrefixes.has(`ns${suffix}`)) suffix++;
+  const generatedPrefix = `ns${suffix}`;
+  usedPrefixes.add(generatedPrefix);
+  prefixesByNamespace.set(namespace, generatedPrefix);
+  return { ...xml, prefix: generatedPrefix };
 }
 
 function qualifiedXmlName(fallbackName: string, xml: UnknownRecord): string {

--- a/plugins/importer-openapi/src/index.ts
+++ b/plugins/importer-openapi/src/index.ts
@@ -1228,13 +1228,11 @@ function qualifyXmlAttribute(
 ): UnknownRecord {
   const namespace = stringAt(xml, "namespace");
   const declaredPrefix = stringAt(xml, "prefix");
-  if (
-    namespace == null ||
-    namespace.length === 0 ||
-    (declaredPrefix != null && declaredPrefix.length > 0)
-  ) {
-    return xml;
+  if (namespace != null && namespace.length === 0) {
+    const { prefix: _prefix, ...unqualifiedXml } = xml;
+    return unqualifiedXml;
   }
+  if (namespace == null || (declaredPrefix != null && declaredPrefix.length > 0)) return xml;
 
   const existingPrefix = prefixesByNamespace.get(namespace);
   if (existingPrefix != null) return { ...xml, prefix: existingPrefix };

--- a/plugins/importer-openapi/src/index.ts
+++ b/plugins/importer-openapi/src/index.ts
@@ -1175,7 +1175,7 @@ function valueToXml(
       const prefix = stringAt(xml, "prefix");
       if (prefix == null || prefix.length === 0) continue;
       usedPrefixes.add(prefix);
-      if (namespace != null && !prefixesByNamespace.has(namespace)) {
+      if (namespace != null && namespace.length > 0 && !prefixesByNamespace.has(namespace)) {
         prefixesByNamespace.set(namespace, prefix);
       }
     }
@@ -1209,9 +1209,9 @@ function xmlElement(
   const namespaces = new Map<string, string>();
   for (const metadata of [xml, ...additionalNamespaces]) {
     const namespace = stringAt(metadata, "namespace");
-    if (namespace == null) continue;
+    if (namespace == null || namespace.length === 0) continue;
     const prefix = stringAt(metadata, "prefix");
-    namespaces.set(prefix == null ? "xmlns" : `xmlns:${prefix}`, namespace);
+    namespaces.set(prefix == null || prefix.length === 0 ? "xmlns" : `xmlns:${prefix}`, namespace);
   }
   const namespaceAttributes = [...namespaces].map(
     ([attribute, namespace]) => `${attribute}="${escapeXml(namespace)}"`,
@@ -1228,7 +1228,13 @@ function qualifyXmlAttribute(
 ): UnknownRecord {
   const namespace = stringAt(xml, "namespace");
   const declaredPrefix = stringAt(xml, "prefix");
-  if (namespace == null || (declaredPrefix != null && declaredPrefix.length > 0)) return xml;
+  if (
+    namespace == null ||
+    namespace.length === 0 ||
+    (declaredPrefix != null && declaredPrefix.length > 0)
+  ) {
+    return xml;
+  }
 
   const existingPrefix = prefixesByNamespace.get(namespace);
   if (existingPrefix != null) return { ...xml, prefix: existingPrefix };
@@ -1244,7 +1250,7 @@ function qualifyXmlAttribute(
 function qualifiedXmlName(fallbackName: string, xml: UnknownRecord): string {
   const name = stringAt(xml, "name") ?? fallbackName;
   const prefix = stringAt(xml, "prefix");
-  return prefix == null ? name : `${prefix}:${name}`;
+  return prefix == null || prefix.length === 0 ? name : `${prefix}:${name}`;
 }
 
 function escapeXml(value: string): string {

--- a/plugins/importer-openapi/tests/index.test.ts
+++ b/plugins/importer-openapi/tests/index.test.ts
@@ -1063,6 +1063,11 @@ describe("importer-openapi", () => {
                           example: "west",
                           xml: { attribute: true, namespace: "urn:tenant" },
                         },
+                        legacy: {
+                          type: "string",
+                          example: "plain",
+                          xml: { attribute: true, namespace: "" },
+                        },
                         tags: {
                           type: "array",
                           example: ["one", "two"],
@@ -1116,7 +1121,8 @@ describe("importer-openapi", () => {
       text:
         '<c:catalog xmlns:c="urn:catalog" xmlns:m="urn:metadata" ' +
         'xmlns:ns1="urn:external" xmlns:ns2="urn:tenant" ' +
-        'm:id="42" ns1:external-id="external" ns2:tenant="acme" ns2:region="west">' +
+        'm:id="42" ns1:external-id="external" ns2:tenant="acme" ns2:region="west" ' +
+        'legacy="plain">' +
         '<t:tags xmlns:t="urn:tags"><tag>one</tag><tag>two</tag></t:tags>' +
         '<a:alias xmlns:a="urn:aliases">Ada</a:alias>' +
         '<a:alias xmlns:a="urn:aliases">A</a:alias>' +

--- a/plugins/importer-openapi/tests/index.test.ts
+++ b/plugins/importer-openapi/tests/index.test.ts
@@ -1043,6 +1043,26 @@ describe("importer-openapi", () => {
                           example: "42",
                           xml: { attribute: true, namespace: "urn:metadata", prefix: "m" },
                         },
+                        externalId: {
+                          type: "string",
+                          example: "external",
+                          xml: {
+                            attribute: true,
+                            name: "external-id",
+                            namespace: "urn:external",
+                            prefix: "ns1",
+                          },
+                        },
+                        tenant: {
+                          type: "string",
+                          example: "acme",
+                          xml: { attribute: true, namespace: "urn:tenant" },
+                        },
+                        region: {
+                          type: "string",
+                          example: "west",
+                          xml: { attribute: true, namespace: "urn:tenant" },
+                        },
                         tags: {
                           type: "array",
                           example: ["one", "two"],
@@ -1094,7 +1114,9 @@ describe("importer-openapi", () => {
 
     expect(imported?.resources.httpRequests[0]?.body).toEqual({
       text:
-        '<c:catalog xmlns:c="urn:catalog" xmlns:m="urn:metadata" m:id="42">' +
+        '<c:catalog xmlns:c="urn:catalog" xmlns:m="urn:metadata" ' +
+        'xmlns:ns1="urn:external" xmlns:ns2="urn:tenant" ' +
+        'm:id="42" ns1:external-id="external" ns2:tenant="acme" ns2:region="west">' +
         '<t:tags xmlns:t="urn:tags"><tag>one</tag><tag>two</tag></t:tags>' +
         '<a:alias xmlns:a="urn:aliases">Ada</a:alias>' +
         '<a:alias xmlns:a="urn:aliases">A</a:alias>' +

--- a/plugins/importer-openapi/tests/index.test.ts
+++ b/plugins/importer-openapi/tests/index.test.ts
@@ -1066,7 +1066,7 @@ describe("importer-openapi", () => {
                         legacy: {
                           type: "string",
                           example: "plain",
-                          xml: { attribute: true, namespace: "" },
+                          xml: { attribute: true, namespace: "", prefix: "unbound" },
                         },
                         tags: {
                           type: "array",


### PR DESCRIPTION
## Summary

- synthesize a deterministic XML prefix when an attribute declares `xml.namespace` without `xml.prefix`
- reuse existing prefixes for the same namespace and avoid collisions with declared or reserved prefixes
- ignore empty namespace metadata and remove its unusable prefix
- cover explicit-prefix collisions, shared generated namespaces, and empty namespaces

## Root cause

XML default namespaces apply to unprefixed elements, not unprefixed attributes. The importer previously emitted `xmlns="…"` on the containing element while leaving the attribute unqualified, so the attribute was not actually in its declared namespace.

The first follow-up also treated an empty namespace string as a real namespace. Depending on whether a prefix was present, that could emit either an invalid empty namespace binding or an attribute with an undeclared prefix.

## Stack

Targets the OpenAPI integration branch after #589. Merge this before continuing with #592.

## Review follow-up

- [Attribute namespace applies to element](https://github.com/mountain-loop/yaak/pull/589#discussion_r3818779529)
- [Reject empty attribute namespaces](https://github.com/mountain-loop/yaak/pull/598#discussion_r3818825721)
- [Empty namespace leaves prefix unbound](https://github.com/mountain-loop/yaak/pull/598#discussion_r3818840693)

## Validation

- `vp test --run tests/index.test.ts` (39 tests)
- `vp lint --type-aware src/index.ts tests/index.test.ts`
- `yaakcli build`