### PR TITLE
fix(appearance): detect the macOS system appearance via NSApp.effectiveAppearance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11723,7 +11723,10 @@ name = "yaak-system-appearance"
 version = "0.1.0"
 dependencies = [
  "dark-light",
+ "dispatch2",
  "log 0.4.29",
+ "objc2-app-kit",
+ "objc2-foundation 0.3.1",
  "tauri",
 ]
 

--- a/crates-tauri/yaak-app-client/src/lib.rs
+++ b/crates-tauri/yaak-app-client/src/lib.rs
@@ -1367,6 +1367,16 @@ pub fn run() {
                         debug!("Launched Yaak {:?}", info);
                     });
                 }
+                RunEvent::WindowEvent { event: WindowEvent::ThemeChanged(_), .. } => {
+                    // On macOS this is how OS appearance changes arrive: tao observes
+                    // AppleInterfaceThemeChangedNotification and emits it for every window
+                    #[cfg(any(target_os = "linux", target_os = "macos"))]
+                    if let Some(state) =
+                        app_handle.try_state::<yaak_system_appearance::SystemAppearanceState>()
+                    {
+                        yaak_system_appearance::emit_change(app_handle, &state);
+                    }
+                }
                 RunEvent::WindowEvent { event: WindowEvent::Focused(true), label, .. } => {
                     #[cfg(any(target_os = "linux", target_os = "macos"))]
                     if let Some(state) =

--- a/crates-tauri/yaak-system-appearance/Cargo.toml
+++ b/crates-tauri/yaak-system-appearance/Cargo.toml
@@ -4,8 +4,13 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 dark-light = "2.0.0"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+dispatch2 = "0.3.0"
+objc2-app-kit = { version = "0.3.1", features = ["NSAppearance", "NSApplication", "NSResponder"] }
+objc2-foundation = { version = "0.3.1", features = ["NSArray", "NSString", "NSUserDefaults"] }
 
 [dependencies]
 log = { workspace = true }

--- a/crates-tauri/yaak-system-appearance/src/lib.rs
+++ b/crates-tauri/yaak-system-appearance/src/lib.rs
@@ -47,14 +47,12 @@ pub fn initialization_script(appearance: Appearance) -> String {
 
 /// Detect the appearance the OS prefers, independent of any appearance that has
 /// been forced onto app windows (which is what the webview itself reports).
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(target_os = "linux")]
 pub fn system_appearance() -> Option<Appearance> {
-    #[cfg(target_os = "linux")]
     if let Some(appearance) = gsettings_system_appearance() {
         return Some(appearance);
     }
 
-    // On macOS this reads AppleInterfaceStyle from the global user defaults
     match dark_light::detect() {
         Ok(dark_light::Mode::Dark) => Some(Appearance::Dark),
         Ok(dark_light::Mode::Light) => Some(Appearance::Light),
@@ -64,6 +62,60 @@ pub fn system_appearance() -> Option<Appearance> {
             None
         }
     }
+}
+
+/// Detect the appearance the OS prefers, independent of any appearance that has
+/// been forced onto app windows (which is what the webview itself reports).
+///
+/// This asks AppKit for the application's effective appearance instead of reading
+/// `AppleInterfaceStyle` from the user defaults: macOS 27 no longer writes that key
+/// when dark mode is on, so anything reading it sees light mode. Appearances forced
+/// per window (yaak-mac-window) don't reach `NSApp`, so this is the OS preference.
+#[cfg(target_os = "macos")]
+pub fn system_appearance() -> Option<Appearance> {
+    use objc2_app_kit::{NSAppearanceNameAqua, NSAppearanceNameDarkAqua, NSApplication};
+    use objc2_foundation::NSArray;
+
+    // AppKit is main-thread only. This runs inline on the main thread and hops over
+    // synchronously from the poll thread.
+    dispatch2::run_on_main(|mtm| {
+        let app = NSApplication::sharedApplication(mtm);
+
+        // An appearance forced on the whole app (tauri's `set_theme` does this) would make
+        // the effective appearance report the override instead of the OS preference. Nothing
+        // in Yaak does that, but fall back to the user defaults if something ever does.
+        //
+        // SAFETY: Called on the main thread with the shared application
+        if unsafe { app.appearance() }.is_some() {
+            return defaults_appearance();
+        }
+
+        // SAFETY: The appearance names are AppKit constants that live for the whole process
+        let (dark, light) = unsafe { (NSAppearanceNameDarkAqua, NSAppearanceNameAqua) };
+        let names = NSArray::from_slice(&[dark, light]);
+        let best = app.effectiveAppearance().bestMatchFromAppearancesWithNames(&names)?;
+
+        // SAFETY: Both are valid strings
+        let is_dark = unsafe { best.isEqualToString(dark) };
+        Some(if is_dark { Appearance::Dark } else { Appearance::Light })
+    })
+}
+
+/// The appearance macOS persists to the global user defaults. Absent means light, except
+/// on macOS 27, which stopped writing the key. Only used when the effective appearance is
+/// forced and can't be trusted.
+#[cfg(target_os = "macos")]
+fn defaults_appearance() -> Option<Appearance> {
+    use objc2_foundation::{NSUserDefaults, ns_string};
+
+    // SAFETY: The standard defaults are a process-wide singleton and the key is a valid string
+    let style = unsafe {
+        NSUserDefaults::standardUserDefaults().stringForKey(ns_string!("AppleInterfaceStyle"))
+    };
+
+    // SAFETY: Both are valid strings
+    let is_dark = style.is_some_and(|style| unsafe { style.isEqualToString(ns_string!("Dark")) });
+    Some(if is_dark { Appearance::Dark } else { Appearance::Light })
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]

--- a/crates-tauri/yaak-system-appearance/src/lib.rs
+++ b/crates-tauri/yaak-system-appearance/src/lib.rs
@@ -1,5 +1,5 @@
 use std::sync::{Arc, Mutex};
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(target_os = "linux")]
 use std::time::Duration;
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -11,7 +11,7 @@ use tauri::{AppHandle, Runtime};
 pub const INITIAL_APPEARANCE_GLOBAL: &str = "__YAAK_INITIAL_APPEARANCE__";
 pub const SYSTEM_APPEARANCE_CHANGE_EVENT: &str = "system_appearance_change";
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(target_os = "linux")]
 const SYSTEM_APPEARANCE_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -67,17 +67,18 @@ pub fn system_appearance() -> Option<Appearance> {
 /// Detect the appearance the OS prefers, independent of any appearance that has
 /// been forced onto app windows (which is what the webview itself reports).
 ///
-/// This asks AppKit for the application's effective appearance instead of reading
-/// `AppleInterfaceStyle` from the user defaults: macOS 27 no longer writes that key
-/// when dark mode is on, so anything reading it sees light mode. Appearances forced
-/// per window (yaak-mac-window) don't reach `NSApp`, so this is the OS preference.
+/// This asks AppKit for the application's effective appearance, the same source tauri
+/// uses for `window.theme()`, instead of reading `AppleInterfaceStyle` from the user
+/// defaults: macOS 27 no longer reliably writes that key when dark mode is on, so anything
+/// reading it sees light mode. Appearances forced per window (yaak-mac-window) don't reach
+/// `NSApp`, so this is the OS preference.
 #[cfg(target_os = "macos")]
 pub fn system_appearance() -> Option<Appearance> {
     use objc2_app_kit::{NSAppearanceNameAqua, NSAppearanceNameDarkAqua, NSApplication};
     use objc2_foundation::NSArray;
 
-    // AppKit is main-thread only. This runs inline on the main thread and hops over
-    // synchronously from the poll thread.
+    // AppKit is main-thread only. Every caller runs there today; this keeps it correct if
+    // one ever doesn't.
     dispatch2::run_on_main(|mtm| {
         let app = NSApplication::sharedApplication(mtm);
 
@@ -102,8 +103,8 @@ pub fn system_appearance() -> Option<Appearance> {
 }
 
 /// The appearance macOS persists to the global user defaults. Absent means light, except
-/// on macOS 27, which stopped writing the key. Only used when the effective appearance is
-/// forced and can't be trusted.
+/// on macOS 27, which stopped reliably writing the key. Only used when the effective
+/// appearance is forced and can't be trusted.
 #[cfg(target_os = "macos")]
 fn defaults_appearance() -> Option<Appearance> {
     use objc2_foundation::{NSUserDefaults, ns_string};
@@ -123,6 +124,9 @@ pub fn system_appearance() -> Option<Appearance> {
     None
 }
 
+/// Start tracking the OS appearance. Linux polls for changes. macOS gets them from tauri's
+/// `WindowEvent::ThemeChanged` (tao observes `AppleInterfaceThemeChangedNotification`), which
+/// the app forwards to [`emit_change`], so no thread is needed there.
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn watch<R: Runtime>(app_handle: AppHandle<R>) -> Option<SystemAppearanceState> {
     let last_appearance = system_appearance();
@@ -132,13 +136,19 @@ pub fn watch<R: Runtime>(app_handle: AppHandle<R>) -> Option<SystemAppearanceSta
     }
 
     let state = SystemAppearanceState { last_appearance: Arc::new(Mutex::new(last_appearance)) };
-    let thread_state = state.clone();
-    let _ = std::thread::spawn(move || {
-        loop {
-            std::thread::sleep(SYSTEM_APPEARANCE_POLL_INTERVAL);
-            emit_change(&app_handle, &thread_state);
-        }
-    });
+
+    #[cfg(target_os = "linux")]
+    {
+        let thread_state = state.clone();
+        let _ = std::thread::spawn(move || {
+            loop {
+                std::thread::sleep(SYSTEM_APPEARANCE_POLL_INTERVAL);
+                emit_change(&app_handle, &thread_state);
+            }
+        });
+    }
+    #[cfg(target_os = "macos")]
+    let _ = app_handle;
 
     Some(state)
 }


### PR DESCRIPTION
## Problem

On macOS 27 the system no longer reliably persists `AppleInterfaceStyle` in the global user defaults when dark mode is on (observed: the key stayed absent across several appearance toggles and only appeared after one of them). The `dark-light` crate (2.0.0, and still 3.0.0) reads only that key and reports light mode when it is absent, so with the appearance setting on "System" Yaak rendered light on a dark system. Older macOS versions write the key, which is why this only shows up on newer machines.

## Fix

`yaak-system-appearance` now asks AppKit for `NSApp.effectiveAppearance` (best match of `darkAqua`/`aqua`), the same source tao uses for `window.theme()`.

- Appearances forced per window by `yaak-mac-window` never reach `NSApp`, so the result is still the OS preference. The user-defaults read is kept only as a fallback if an appearance is ever forced on the whole app (tauri `set_theme`), which nothing does today.
- macOS no longer polls. tao observes `AppleInterfaceThemeChangedNotification` and surfaces it as `WindowEvent::ThemeChanged`; the app forwards that to `emit_change`, next to the existing focus re-check. Linux keeps its 1s poll.
- `dark-light` becomes a Linux-only dependency. No new crate versions: `objc2-app-kit`, `objc2-foundation` and `dispatch2` were already in the lockfile.

## Why not Tauri's theme API directly?

#540 assumed per-window forced appearances poison Tauri's theme events as well as CSS media queries. They poison CSS, but tao reads the app-level `NSApp.effectiveAppearance`, so Tauri's value was fine; the problem was the `AppleInterfaceStyle` read. The crate is still needed to inject the initial value synchronously before first paint (no window exists to ask yet) and for Linux/CEF.

## Verification

- `cargo check -p yaak-app-client --features wry`, and `clippy`/`test` on the crate: clean.
- On a macOS 27 machine with no `AppleInterfaceStyle` key: detection returns `Dark`; four appearance toggles (keyboard shortcut and Control Center) each produced a `System appearance changed to …` event via `ThemeChanged`, with no poll thread present in a process sample.
- The Linux path is unchanged apart from removing an inner `#[cfg]`; not compiled on Linux locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
