### PR TITLE
fix(auth-oauth1): use the signing key as the PLAINTEXT signature

### DIFF
--- a/plugins/auth-oauth1/package.json
+++ b/plugins/auth-oauth1/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "build": "yaakcli build",
-    "dev": "yaakcli dev"
+    "dev": "yaakcli dev",
+    "test": "vp test --run tests"
   },
   "dependencies": {
     "oauth-1.0a": "^2.2.6"

--- a/plugins/auth-oauth1/src/index.ts
+++ b/plugins/auth-oauth1/src/index.ts
@@ -202,7 +202,10 @@ function hashFunction(signatureMethod: SigMethod) {
       return (base: string, privateKey: string) =>
         crypto.createSign("RSA-SHA512").update(base).sign(privateKey, "base64");
     case signatures.PLAINTEXT:
-      return (base: string) => base;
+      // RFC 5849 3.4.4: the PLAINTEXT signature IS the signing key,
+      // `encoded(consumer secret)&encoded(token secret)`. Returning the base
+      // string put the whole percent-encoded request into oauth_signature.
+      return (_base: string, key: string) => key;
     default:
       return (base: string, key: string) =>
         crypto.createHmac("sha1", key).update(base).digest("base64");

--- a/plugins/auth-oauth1/tests/plaintext.test.ts
+++ b/plugins/auth-oauth1/tests/plaintext.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vite-plus/test";
+import { plugin } from "../src";
+
+function sign(values: Record<string, string>): string {
+  const result = plugin.authentication!.onApply!(
+    {} as never,
+    {
+      values,
+      method: "GET",
+      url: "https://api.example.com/resource",
+    } as never,
+  ) as { setHeaders: { name: string; value: string }[] };
+  const header = result.setHeaders[0]!.value;
+  const match = header.match(/oauth_signature="([^"]*)"/);
+  return decodeURIComponent(match![1]!);
+}
+
+describe("PLAINTEXT signature", () => {
+  const base = {
+    signatureMethod: "PLAINTEXT",
+    consumerKey: "ck",
+    consumerSecret: "cs",
+    nonce: "abc123",
+    timestamp: "1700000000",
+  };
+
+  // RFC 5849 3.4.4: the PLAINTEXT signature is the signing key itself --
+  // encoded(consumer secret) "&" encoded(token secret) -- not the base string.
+  test("is the signing key, not the signature base string", () => {
+    expect(sign({ ...base, tokenKey: "tk", tokenSecret: "ts" })).toBe("cs&ts");
+  });
+
+  test("keeps the trailing separator when there is no token secret", () => {
+    expect(sign(base)).toBe("cs&");
+  });
+
+  test("percent-encodes reserved characters in the secrets", () => {
+    expect(sign({ ...base, consumerSecret: "c s", tokenKey: "tk", tokenSecret: "t&s" })).toBe(
+      "c%20s&t%26s",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

OAuth 1.0 with `PLAINTEXT` sent the *signature base string* as `oauth_signature` instead of the signing key, so no server could validate the request. RFC 5849 §3.4.4 defines the PLAINTEXT signature as the signing key itself — `encoded(consumer secret) "&" encoded(token secret)`.

## Submission

- [x] This PR is a bug fix.
- [ ] If this PR is not a bug fix, I linked the feedback item where @gschier explicitly gave me permission to work on it.
- [x] I have read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
- [x] I tested this change locally.
- [x] I added or updated tests, or tests are not reasonable for this change.
- [x] I added screenshots or recordings, or this change does not affect the UI.

Explicit permission feedback item (required if not a bug fix):

n/a — bug fix.

## Related

No existing issue; found while reading `plugins/auth-oauth1`.

---

### What went out

```
oauth_signature="GET%26https%253A%252F%252Fapi.example.com%252Fresource%26oauth_consumer_key
%253Dck%2526oauth_nonce%253Dabc123%2526oauth_signature_method%253DPLAINTEXT%2526oauth_timestamp
%253D1700000000%2526oauth_token%253Dtk%2526oauth_version%253D1.0"
```

### What should go out

```
oauth_signature="cs%26ts"        (raw: cs&ts)
```

### Why

`hashFunction()` returned the base string for PLAINTEXT:

```ts
case signatures.PLAINTEXT:
  return (base: string) => base;
```

`oauth-1.0a` calls `hash_function(baseString, signingKey)` and the second argument was simply dropped.

What makes it easy to miss: the library **already ships the correct behaviour** — but only when the caller supplies no `hash_function` of its own:

```js
// node_modules/oauth-1.0a/oauth-1.0a.js
if (this.signature_method == 'PLAINTEXT' && !opts.hash_function) {
    opts.hash_function = function (base_string, key) { return key; }
}
```

The plugin passes `hash_function` unconditionally at construction, so that default was always shadowed. Returning the key restores it.

I chose to fix the `case` rather than conditionally omit `hash_function` from the constructor, so the correct behaviour is visible in the plugin next to the other signature methods instead of depending on a library default.

### Verified

Ran the three signature paths through `oauth-1.0a` directly:

```
plugin, before  ->  "GET&https%3A%2F%2Fapi.example.com%2Fresource&oauth_consumer_key%3Dck…"
library default ->  "cs&ts"
plugin, after   ->  "cs&ts"
```

### Tests

`plugins/auth-oauth1` had no tests, so this adds the first ones, following the `auth-oauth2` layout (`tests/` plus the same `"test": "vp test --run tests"` script). They go through `plugin.authentication.onApply` and assert the emitted `oauth_signature`:

- it is the signing key, not the base string
- the trailing `&` survives when there is no token secret (`cs&`)
- reserved characters in either secret are percent-encoded (`c%20s&t%26s`)

All three **fail on `main`** and pass with the change:

```
$ npx vp test --run plugins/auth-oauth1/tests      # src/index.ts reverted
 FAIL  > is the signing key, not the signature base string
   expected 'GET&https%3A%2F%2Fapi.example.com%2Fr…' to be 'cs&ts'
 FAIL  > keeps the trailing separator when there is no token secret
 FAIL  > percent-encodes reserved characters in the secrets
  Tests  3 failed (3)

$ npx vp test --run plugins/auth-oauth1/tests      # with the fix
  Tests  3 passed (3)
```

HMAC-SHA1/256/512 and the RSA-* methods are untouched — only the `PLAINTEXT` case changes.