### PR TITLE
fix(importer-curl): keep an = inside --url-query and form values

### DIFF
--- a/plugins/importer-curl/src/index.ts
+++ b/plugins/importer-curl/src/index.ts
@@ -359,7 +359,9 @@ function importCommand(parseEntries: string[], workspaceId: string) {
     if (typeof p !== "string") {
       continue;
     }
-    const [name, value] = p.split("=");
+    // splitOnce: a query value may itself contain "=" (a base64 payload, a
+    // nested filter), and only the first one separates name from value.
+    const [name, value] = splitOnce(p, "=");
     urlParameters.push({
       name: name ?? "",
       value: value ?? "",
@@ -475,7 +477,9 @@ function importCommand(parseEntries: string[], workspaceId: string) {
     ...((flagsByName.form as string[] | undefined) || []),
     ...((flagsByName.F as string[] | undefined) || []),
   ].map((str) => {
-    const parts = str.split("=");
+    // splitOnce for the same reason as --url-query above: base64 padding
+    // ("...==") and any value containing "=" must survive intact.
+    const parts = splitOnce(str, "=");
     const name = parts[0] ?? "";
     const value = parts[1] ?? "";
     const item: { name: string; value?: string; file?: string; enabled: boolean } = {

--- a/plugins/importer-curl/tests/index.test.ts
+++ b/plugins/importer-curl/tests/index.test.ts
@@ -942,6 +942,23 @@ describe("importer-curl", () => {
       },
     });
   });
+  test("Keeps an = inside a --url-query value", () => {
+    const imported = convertCurl(
+      'curl --url-query "filter=type=book" --url-query "t=eyJhIjoxfQ==" https://yaak.app',
+    );
+    expect(imported.resources.httpRequests?.[0]?.urlParameters).toEqual([
+      { enabled: true, name: "filter", value: "type=book" },
+      { enabled: true, name: "t", value: "eyJhIjoxfQ==" },
+    ]);
+  });
+
+  test("Keeps an = inside a form value", () => {
+    const imported = convertCurl('curl -F "t=eyJhIjoxfQ==" -F "q=a=b" https://yaak.app');
+    expect(imported.resources.httpRequests?.[0]?.body?.form).toEqual([
+      { enabled: true, name: "t", value: "eyJhIjoxfQ==" },
+      { enabled: true, name: "q", value: "a=b" },
+    ]);
+  });
 });
 
 const idCount: Partial<Record<string, number>> = {};


### PR DESCRIPTION
## Summary

`--url-query` and `-F/--form` split their argument on **every** `=` and kept only the first two pieces, so any value containing `=` was silently truncated on import. Both now use the file's existing `splitOnce` helper.

## Submission

- [x] This PR is a bug fix.
- [ ] If this PR is not a bug fix, I linked the feedback item where @gschier explicitly gave me permission to work on it.
- [x] I have read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
- [x] I tested this change locally.
- [x] I added or updated tests, or tests are not reasonable for this change.
- [x] I added screenshots or recordings, or this change does not affect the UI.

Explicit permission feedback item (required if not a bug fix):

n/a — bug fix.

## Related

Same class as the `--data-urlencode` truncation fixed in #597; these are the two call sites that were left on `.split("=")`.

---

### What breaks

```
curl --url-query "filter=type=book" https://yaak.app
  before   filter = "type"          <- "=book" dropped
  after    filter = "type=book"

curl -F "t=eyJhIjoxfQ==" https://yaak.app
  before   t = "eyJhIjoxfQ"         <- base64 padding dropped
  after    t = "eyJhIjoxfQ=="
```

Base64 payloads (which end in `=` or `==` by construction) and nested filter syntax are the everyday cases. The value is lost quietly — the import succeeds and the request just carries the wrong data.

### The fix

`splitOnce` already exists in this file and is already used for the URL's own query string (`splitOnce(p, "=")`) and for `--data-urlencode`. These two call sites simply never got it:

```ts
const [name, value] = p.split("=");     // --url-query
const parts = str.split("=");           // -F / --form
```

Both now call `splitOnce`, so only the first `=` separates name from value.

### Tests

Two regression tests, appended at the end of the `importer-curl` describe block. They **fail on `main`** and pass with the change:

```
$ npx vp test --run plugins/importer-curl/tests     # src reverted
 FAIL  > Keeps an = inside a --url-query value
 FAIL  > Keeps an = inside a form value
  Tests  2 failed | 58 passed (60)

$ npx vp test --run plugins/importer-curl/tests     # with the fix
  Tests  60 passed (60)
```

Worth knowing for anyone adding tests to this file later: `baseRequest()` / `baseWorkspace()` share a module-level `idCount`, so inserting a test in the middle of the block shifts the expected ids of every test after it. I hit that first (34 unrelated failures) and moved the new tests to the end — the existing 58 are untouched either way.