### PR TITLE
fix(template-function-json): escape control characters in json.escape

### DIFF
--- a/plugins/template-function-json/package.json
+++ b/plugins/template-function-json/package.json
@@ -8,7 +8,8 @@
   "types": "src/index.ts",
   "scripts": {
     "build": "yaakcli build",
-    "dev": "yaakcli dev"
+    "dev": "yaakcli dev",
+    "test": "vp test --run tests"
   },
   "dependencies": {
     "jsonpath-plus": "^10.3.0"

--- a/plugins/template-function-json/src/index.ts
+++ b/plugins/template-function-json/src/index.ts
@@ -85,7 +85,11 @@ export const plugin: PluginDefinition = {
       ],
       async onRender(_ctx: Context, args: CallTemplateFunctionArgs): Promise<string | null> {
         const input = String(args.values.input ?? "");
-        return input.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+        // JSON.stringify produces a spec-correct string literal: it escapes
+        // the backslash and quote this used to handle, and also the control
+        // characters it did not. Slicing off the surrounding quotes leaves
+        // the escaped inner text this function is meant to emit.
+        return JSON.stringify(input).slice(1, -1);
       },
     },
     {

--- a/plugins/template-function-json/tests/escape.test.ts
+++ b/plugins/template-function-json/tests/escape.test.ts
@@ -1,0 +1,50 @@
+import type { Context } from "@yaakapp/api";
+import { describe, expect, it } from "vite-plus/test";
+import { plugin } from "../src";
+
+const LF = String.fromCharCode(10);
+const TAB = String.fromCharCode(9);
+const CR = String.fromCharCode(13);
+
+describe("json.escape", () => {
+  const escapeFunction = plugin.templateFunctions?.find((f) => f.name === "json.escape");
+
+  const escape = async (input: string) =>
+    await escapeFunction!.onRender({} as Context, { values: { input } } as never);
+
+  // The point of the function is that the result can be dropped between two
+  // quotes in a JSON document, so that is what these assert.
+  const embeds = (escaped: string | null) => {
+    JSON.parse(`{"k":"${escaped}"}`);
+    return JSON.parse(`{"k":"${escaped}"}`).k;
+  };
+
+  it("should exist", () => {
+    expect(escapeFunction).toBeTruthy();
+  });
+
+  it("escapes a quote", async () => {
+    const input = `say "hi"`;
+    expect(embeds(await escape(input))).toBe(input);
+  });
+
+  it("escapes a backslash", async () => {
+    const input = `a${String.fromCharCode(92)}b`;
+    expect(embeds(await escape(input))).toBe(input);
+  });
+
+  it("escapes a newline", async () => {
+    const input = `line1${LF}line2`;
+    expect(embeds(await escape(input))).toBe(input);
+  });
+
+  it("escapes a tab and a carriage return", async () => {
+    const input = `a${TAB}b${CR}c`;
+    expect(embeds(await escape(input))).toBe(input);
+  });
+
+  it("round-trips a pretty-printed JSON document", async () => {
+    const input = JSON.stringify({ name: `he said "hi"`, items: [1, 2] }, null, 2);
+    expect(embeds(await escape(input))).toBe(input);
+  });
+});


### PR DESCRIPTION
## Summary

`json.escape` escaped only the backslash and the quote, so any input containing a newline, tab or carriage return produced a string that is not a valid JSON literal — and the request body it was embedded in failed to parse.

## Submission

- [x] This PR is a bug fix.
- [ ] If this PR is not a bug fix, I linked the feedback item where @gschier explicitly gave me permission to work on it.
- [x] I have read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
- [x] I tested this change locally.
- [x] I added or updated tests, or tests are not reasonable for this change.
- [x] I added screenshots or recordings, or this change does not affect the UI.

Explicit permission feedback item (required if not a bug fix):

n/a — bug fix.

## Related

No existing issue; found while reading `plugins/template-function-json`.

---

### What breaks

```
{"note":"${[ json.escape(input='line1<newline>line2') ]}"}

  SyntaxError: Bad control character in string literal in JSON at position 11
```

The archetypal use of this function — pasting a pretty-printed JSON document into a request body — hits it on the very first line break.

### Why

```ts
return input.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
```

Two of the seven characters JSON requires escaping. The C0 controls (`\n`, `\t`, `\r`, `\b`, `\f`, and `\u00XX` for the rest) all went through untouched.

`JSON.stringify` builds a spec-correct string literal, and slicing off its surrounding quotes leaves exactly the inner text this function is meant to emit.

### Output is unchanged for everything that already worked

| input | old | new |
|---|---|---|
| `plain` | parses | parses — **identical output** |
| `a\b` | parses | parses — **identical output** |
| `say "hi"` | parses | parses — **identical output** |
| `line1⏎line2` | **INVALID** | parses |
| `a⇥b` | **INVALID** | parses |
| `cr␍end` | **INVALID** | parses |

So this only adds escaping where there was none; it does not re-shape output that was already valid.

### Tests

`plugins/template-function-json` had no tests, so this adds the first ones, following the `template-function-regex` layout (`tests/` plus the same `"test": "vp test --run tests"` script).

They assert the real property that matters rather than a literal string — that the result can be dropped between two quotes in a JSON document and round-trips back to the original input.

Three of them **fail on `main`**:

```
$ npx vp test --run plugins/template-function-json/tests    # src reverted
 FAIL  > escapes a newline
   SyntaxError: Bad control character in string literal in JSON at position 11
 FAIL  > escapes a tab and a carriage return
 FAIL  > round-trips a pretty-printed JSON document
  Tests  3 failed | 3 passed (6)

$ npx vp test --run plugins/template-function-json/tests    # with the fix
  Tests  6 passed (6)
```

`json.jsonpath` and `json.minify` in the same plugin are untouched.