### PR TITLE
fix(tooling): keep the formatter off generated files in every entry point

### DIFF
--- a/.oxfmtignore
+++ b/.oxfmtignore
@@ -1,3 +1,0 @@
-**/bindings/**
-**/routeTree.gen.ts
-crates/yaak-templates/pkg/**

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "lint:vp": "vp lint",
     "lint:workspaces": "npm run --workspaces --if-present lint",
     "replace-version": "node scripts/replace-version.cjs",
-    "format": "vp fmt --ignore-path .oxfmtignore",
+    "format": "vp fmt",
     "tauri": "tauri",
     "client:tauri-before-build": "npm run bootstrap",
     "client:tauri-before-dev": "node scripts/run-workspaces-dev.mjs apps/yaak-client",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,8 +4,23 @@ export default defineConfig({
   staged: {
     "*": "vp check --fix",
   },
+  // Generated output, reformatted only to be undone by the next regen. Read by every formatter
+  // entry point, including the `staged` task above.
+  fmt: {
+    ignorePatterns: [
+      "**/bindings/**",
+      "**/routeTree.gen.ts",
+      "crates/yaak-templates/pkg/**",
+      "crates/yaak-wasm/pkg/**",
+    ],
+  },
   lint: {
-    ignorePatterns: ["npm/**", "crates/yaak-templates/pkg/**", "crates/yaak-wasm/pkg/**", "**/bindings/gen_*.ts"],
+    ignorePatterns: [
+      "npm/**",
+      "crates/yaak-templates/pkg/**",
+      "crates/yaak-wasm/pkg/**",
+      "**/bindings/gen_*.ts",
+    ],
     options: {
       typeAware: true,
     },


### PR DESCRIPTION
The pre-commit `staged` task runs `vp check --fix`, which formats whatever is staged. The ignore list lived in `.oxfmtignore`, and only the root `format` script passed it along via `--ignore-path`. So committing a bindings regen reflowed files whose own header says not to edit them by hand, and the next `cargo test` regen undid it.

Hit this on #614: committing through the hook turned a +742/-19 change into +2627/-1183, nearly all of it reflowing `gen_events.ts`.

`vp check` has no `--ignore-path`, so the list moves to `fmt.ignorePatterns` in the vite config, which every formatter entry point reads. `.oxfmtignore` is deleted and the `format` script drops the flag, leaving one source of truth.

Also adds `crates/yaak-wasm/pkg/**`. It is tracked wasm-pack output and was already in `lint.ignorePatterns`, just missing from the formatter's list — the same bug waiting on the next wasm rebuild.

`npm/**` is deliberately left formatted. It is lint-ignored, but those manifests are hand-maintained rather than generated.

## Verified

Staged `gen_events.ts` and ran `vp staged`: file comes back byte-identical (649 lines, same md5). Before the fix the same path reflowed it to 548 lines. `vp check --fix` on an ignored file exits 0, so a commit containing only generated files is not blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
