### PR TITLE
fix(pair-editor): remount the editor when its stateKey changes

### DIFF
--- a/apps/yaak-client/components/core/PairEditor.tsx
+++ b/apps/yaak-client/components/core/PairEditor.tsx
@@ -113,7 +113,15 @@ function toPairData({ commitName: _commitName, ...pair }: EditablePairWithId): P
 /** Max number of pairs to show before prompting the user to reveal the rest */
 const MAX_INITIAL_PAIRS = 30;
 
-export function PairEditor({
+// Keyed on `stateKey` so no state survives a change of owner. Row ids alone can't tell owners
+// apart — two pair sets can share ids (eg. one duplicated from the other), and the same-rows
+// fast path below would swap in the new data without rebuilding the row editors, leaving any
+// still-focused input showing the old owner's text.
+export function PairEditor(props: PairEditorProps) {
+  return <PairEditorInner key={props.stateKey} {...props} />;
+}
+
+function PairEditorInner({
   allowFileValues,
   allowMultilineValues,
   className,


### PR DESCRIPTION
## Problem

Reported in [feedback](https://yaak.app/feedback/posts/if-i-duplicate-request-and-modify-one-the-other-one-gets-modified-as-well): duplicate a request, modify a param, and the other request's param appears modified as well.

Duplicating a request copies its pairs verbatim, ids included (`duplicate_http_request` clones the whole model), so two duplicates present identical row ids to the pair editor. The same-rows fast path added for path placeholder renaming (#528) matched on ids alone, so switching between duplicates swapped row data in without re-initializing the row editors. A still-focused input never re-seeds from `defaultValue` — and in the macOS webview, clicking the sidebar does not blur the field — leaving one request's text displayed, and committable, on top of the other request's data.

This is why the Params tab reproduced but Headers didn't in testing: it depends on whether the pairs existed before duplication (shared ids), not on the tab. Headers added after duplicating get fresh ids and take the full rebuild path.

## Fix

Wrap the editor in a private `PairEditorInner` keyed on `stateKey`, so a change of owner remounts the whole editor and no state (rows, drag state, show-all toggle, focus bookkeeping) carries over. Within one request `stateKey` is stable, so the fast path keeps preserving focus across placeholder renames as #528 intended.

A follow-up will regenerate pair ids in the Rust duplicate paths so copies never share row identities in the first place.

## Testing

- `tsc --noEmit` clean for the change (remaining errors are pre-existing dependency typing issues)
- `vitest` pair editor suites pass (39 tests)

To verify manually: request with a param → duplicate → edit the param name → switch between the two requests; each request's name field should show its own value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)