### PR TITLE
fix(importer-postman): stop swapping the API key name and its value

### DIFF
--- a/plugins/importer-postman/src/index.ts
+++ b/plugins/importer-postman/src/index.ts
@@ -294,8 +294,10 @@ function importAuth(rawAuth: unknown): Pick<HttpRequest, "authentication" | "aut
       authenticationType: "apikey",
       authentication: {
         location: a.in === "query" ? "query" : "header",
-        key: a.value != null ? String(a.value) : undefined,
-        value: a.key != null ? String(a.key) : undefined,
+        // Postman's "key" is the header/parameter name and its "value" is the
+        // secret, matching Yaak's own apikey auth.
+        key: a.key != null ? String(a.key) : undefined,
+        value: a.value != null ? String(a.value) : undefined,
       },
     };
   }

--- a/plugins/importer-postman/tests/fixtures/auth.input.json
+++ b/plugins/importer-postman/tests/fixtures/auth.input.json
@@ -659,12 +659,12 @@
             },
             {
               "key": "value",
-              "value": "value",
+              "value": "secret-123",
               "type": "string"
             },
             {
               "key": "key",
-              "value": "key",
+              "value": "X-API-Key",
               "type": "string"
             }
           ]

--- a/plugins/importer-postman/tests/fixtures/auth.output.json
+++ b/plugins/importer-postman/tests/fixtures/auth.output.json
@@ -271,8 +271,8 @@
         "authenticationType": "apikey",
         "authentication": {
           "location": "query",
-          "key": "value",
-          "value": "key"
+          "key": "X-API-Key",
+          "value": "secret-123"
         }
       },
       {


### PR DESCRIPTION
## Summary

The Postman importer assigns API Key auth crosswise, so an imported request sends the secret as the header name and the header name as the secret. Restore the identity mapping and make the fixture non-degenerate so the swap cannot hide again.

## Submission

- [x] This PR is a bug fix.
- [ ] If this PR is not a bug fix, I linked the feedback item where @gschier explicitly gave me permission to work on it.
- [x] I have read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
- [x] I tested this change locally.
- [x] I added or updated tests, or tests are not reasonable for this change.
- [x] I added screenshots or recordings, or this change does not affect the UI.

## Detail

`pmArrayToObj` keys Postman's array by the parameter *name*:

```ts
if (typeof ii.key === "string") {
  o[ii.key] = ii.value;
}
```

so for a Postman apikey block, `a.key` is the header/query parameter name and `a.value` is the secret. `importAuth` then reverses them:

```ts
key: a.value != null ? String(a.value) : undefined,
value: a.key != null ? String(a.key) : undefined,
```

That is the opposite of what the field means everywhere else. `auth-apikey` labels `key` as "Header Name" / "Parameter Name" and `value` as "API Key" with `password: true`, and applies them as `setHeaders: [{ name: key, value }]`. The sibling branches in this same function — `basic`, `bearer`, `awsv4` — all map straight across; `apikey` is the only one that crosses.

A collection importing `X-API-Key: secret-123` therefore produces a request that sends `secret-123: X-API-Key`. It fails with 401/403, and because the masking follows the field rather than the content, the secret ends up displayed in the plaintext "Key" box while the harmless header name sits behind the password mask.

## Why the tests did not catch it

`auth.input.json` used the degenerate values `key="key"` and `value="value"`, so the swapped output read `{"key": "value", "value": "key"}` — which looks plausible enough to bless. This PR changes them to `X-API-Key` and `secret-123`.

## Test plan

- Ran the three importer fixtures through `convertPostman` and compared against their `.output.json` exactly as `tests/index.test.ts` does → all three match.
- Checked: restoring only the swap fails `auth.input.json` with `"key": "secret-123"` where `"key": "X-API-Key"` is expected.
- No UI change; the only surface is the imported request's auth fields.