### PR TITLE
fix(importer-curl): join line continuations that have trailing whitespace

### DIFF
--- a/plugins/importer-curl/src/index.ts
+++ b/plugins/importer-curl/src/index.ts
@@ -98,8 +98,12 @@ export const plugin: PluginDefinition = {
  * Handles line continuations, semicolons, and newline-separated curl commands.
  */
 function splitCommands(rawData: string): string[] {
-  // Join line continuations (backslash-newline, and backslash-CRLF for Windows)
-  const joined = rawData.replace(/\\\r?\n/g, " ");
+  // Join line continuations (backslash-newline, and backslash-CRLF for
+  // Windows). Trailing spaces or tabs after the backslash are common when a
+  // command is copied from a terminal or a doc, and the shell treats
+  // "\ <newline>" as an escaped space rather than a continuation, so accept
+  // them here to keep the pasted command in one piece.
+  const joined = rawData.replace(/\\[ \t]*\r?\n/g, " ");
 
   // Count consecutive backslashes immediately before position i.
   // An even count means the quote at i is NOT escaped; odd means it IS escaped.

--- a/plugins/importer-curl/tests/index.test.ts
+++ b/plugins/importer-curl/tests/index.test.ts
@@ -142,6 +142,33 @@ describe("importer-curl", () => {
     });
   });
 
+  // A trailing space after the continuation backslash is invisible in most
+  // editors but used to stop the join, so the quoted body split across
+  // lines and the parser failed with "Got EOF while in a quoted string".
+  test("Imports line continuations with trailing whitespace after the backslash", () => {
+    expect(
+      convertCurl(
+        "curl -X POST https://yaak.app \\ \n  -H 'Content-Type: application/json' \\\t\n  --data '{\"a\":1}' \\ \r\n  -H 'Accept: application/json'",
+      ),
+    ).toEqual({
+      resources: {
+        workspaces: [baseWorkspace()],
+        httpRequests: [
+          baseRequest({
+            url: "https://yaak.app",
+            method: "POST",
+            headers: [
+              { name: "Content-Type", value: "application/json", enabled: true },
+              { name: "Accept", value: "application/json", enabled: true },
+            ],
+            bodyType: "application/json",
+            body: { text: '{"a":1}' },
+          }),
+        ],
+      },
+    });
+  });
+
   test("Imports with Windows CRLF line endings", () => {
     expect(convertCurl("curl \\\r\n  -X POST \\\r\n  https://yaak.app")).toEqual({
       resources: {


### PR DESCRIPTION
## Summary

A space or tab after a line-continuation backslash (`\ ` followed by a newline) stopped `splitCommands` from joining the lines, so a quoted `--data` body split at the newline and the parser failed with `Got EOF while in a quoted string` (or `... in an escape sequence`). The join now accepts spaces and tabs before the newline. It deliberately does not accept `\s*`, which would also swallow blank lines that separate commands.

## Submission

- [x] This PR is a bug fix.
- [ ] If this PR is not a bug fix, I linked the feedback item where @gschier explicitly gave me permission to work on it.
- [x] I have read and followed [`CONTRIBUTING.md`](CONTRIBUTING.md).
- [x] I tested this change locally.
- [x] I added or updated tests, or tests are not reasonable for this change.
- [x] I added screenshots or recordings, or this change does not affect the UI.

## Detail

`plugins/importer-curl/src/index.ts` joined continuations with `/\\\r?\n/g`. Trailing whitespace is invisible in most editors and common when copying multi-line commands (Postman's "Copy as cURL", terminals, docs), and `bash` itself treats `\ ` + newline as an escaped space rather than a continuation, so the importer is the right place to tolerate it.

The new test feeds a POST with three continuations: one followed by a space, one by a tab, and one by a space before CRLF. Without the fix it fails with `Got EOF while in an escape sequence`; with it, all 62 importer tests pass (`vp test --run tests`). `vp fmt --check` is clean.

## Related

Reported at https://yaak.app/feedback/posts/importer-curl-got-eof-while-in-a-quoted-string-when-trailing-spaces-exist-after-

🤖 Generated with [Claude Code](https://claude.com/claude-code)